### PR TITLE
fix: Throw an error if cache directory is not writable 

### DIFF
--- a/src/segcore_wrapper.h
+++ b/src/segcore_wrapper.h
@@ -17,6 +17,12 @@
 #include <cstdint>
 #include <string>
 #include <vector>
+#include <filesystem>
+#include <stdexcept>
+#include <system_error>
+#include <unistd.h>
+#include <cstdlib>
+#include <cstring>
 #include "status.h"
 #include "retrieve_result.h"
 #include "search_result.h"
@@ -25,13 +31,51 @@
 #include "segcore/segment_c.h"
 #include "storage/storage_c.h"
 namespace milvus::local {
-const std::string data_path =
-    std::string(std::getenv("HOME")) + "/.cache/milvus";
+std::string GetDataPath() {
+    const char* home = std::getenv("HOME");
+    if (home == nullptr) {
+        throw std::runtime_error("HOME environment variable is not set. Please set HOME environment variable.");
+    }
+    
+    std::string data_path = std::string(home) + "/.cache/milvus";
+    
+    try {
+        std::filesystem::create_directories(data_path);
+    } catch (const std::exception& e) {
+        throw std::runtime_error("Cannot create cache directory '" + data_path + "': " + e.what());
+    }
+    
+    if (!std::filesystem::is_directory(data_path)) {
+        throw std::runtime_error("Cache path '" + data_path + "' is not a directory.");
+    }
+    
+    std::string test_pattern = data_path + "/.perm-probeXXXXXX";
+    char test_file[test_pattern.length() + 1];
+    strcpy(test_file, test_pattern.c_str());
+    
+    int fd = mkstemp(test_file);
+    if (fd == -1) {
+        throw std::runtime_error("Cache directory '" + data_path + "' is not writable by current user. Please check permissions.");
+    }
+    
+    close(fd);
+    unlink(test_file);
+    
+    return data_path;
+}
+
+const std::string data_path = GetDataPath();
+
 class SegcoreWrapper final : NonCopyableNonMovable {
  public:
     SegcoreWrapper() : collection_(nullptr), cur_id_(0), segment_(nullptr) {
         SegcoreSetEnableInterminSegmentIndex(true);
-        InitLocalChunkManagerSingleton(data_path.c_str());
+        
+        auto status = InitLocalChunkManagerSingleton(data_path.c_str());
+        if (status.error_code != 0) {
+            throw std::runtime_error("Failed to initialize LocalChunkManager: " + std::string(status.error_msg));
+        }
+        
         CMmapConfig conf;
         conf.growing_enable_mmap = false;
         conf.scalar_index_enable_mmap = false;
@@ -42,7 +86,11 @@ class SegcoreWrapper final : NonCopyableNonMovable {
         conf.vector_field_enable_mmap = false;
         conf.vector_index_enable_mmap = false;
         conf.fix_file_size = 1024;
-        InitMmapManager(conf);
+        
+        status = InitMmapManager(conf);
+        if (status.error_code != 0) {
+            throw std::runtime_error("Failed to initialize MmapManager: " + std::string(status.error_msg));
+        }
     }
     virtual ~SegcoreWrapper();
 


### PR DESCRIPTION
When running on a system with `~/.cache` not writable by the user (e.g. in locked-down environments in Kubernetes/OpenShift), this obscure error message happens:

```
2025-07-29 09:29:23,387 [INFO][connect]: Pass in the local path ./milvus_demo_roland.db, and run it using milvus-lite (connections.py:373)
/opt/app-root/lib64/python3.12/site-packages/milvus_lite/__init__.py:15: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  from pkg_resources import DistributionNotFound, get_distribution
Assert "init_flag_ == true"  => Mmap manager has not been init. at /workspace/milvus-lite/thirdparty/milvus/internal/core/src/storage/MmapManager.h:96

2025-07-29 09:29:34,008 [ERROR][handler]: RPC error: [create_collection], <MilvusException: (code=2000, message=Assert "init_flag_ == true"  => Mmap manager has not been init. at /workspace/milvus-lite/thirdparty/milvus/internal/core/src/storage/MmapManager.h:96
: segcore error)>, <Time:{'RPC start': '2025-07-29 09:29:34.006279', 'RPC error': '2025-07-29 09:29:34.008019'}> (decorators.py:140)
....
```

The Mmap manager is not initialized because the cache directory creation fails, but this error is ignored.

This PR checks explicitly whether the directory is creatable and also verifies the return values of the init functions.