### PR TITLE
fix: Update Docker images to use Rust 1.89.0

### DIFF
--- a/scripts/Dockerfile.manylinux.aarch64
+++ b/scripts/Dockerfile.manylinux.aarch64
@@ -15,7 +15,7 @@ FROM quay.io/pypa/manylinux_2_28_aarch64:2024.07.07-1
 RUN  yum install -y openblas-devel libatomic-static git && cp /usr/lib/gcc/aarch64-redhat-linux/8/libatomic.a /usr/lib64/
 ENV PATH="/opt/_internal/cpython-3.8.19/bin:${PATH}"
 RUN pip3 install conan==1.63.0
-RUN curl https://sh.rustup.rs -sSf | bash -s -- --default-toolchain=1.73 -y
+RUN curl https://sh.rustup.rs -sSf | bash -s -- --default-toolchain=1.89 -y
 ENV PATH="/root/.cargo/bin:${PATH}"
 ENV CCFLAGS="-Wno-error=address"
 ENV CXXFLAGS="-Wno-error=address"

--- a/scripts/Dockerfile.manylinux.x86_64
+++ b/scripts/Dockerfile.manylinux.x86_64
@@ -15,7 +15,7 @@ FROM quay.io/pypa/manylinux_2_28_x86_64:2024.07.07-1
 RUN  yum install -y openblas-devel libatomic-static git && cp /usr/lib/gcc/x86_64-redhat-linux/8/libatomic.a /usr/lib64/
 ENV PATH="/opt/_internal/cpython-3.8.19/bin:${PATH}"
 RUN pip3 install conan==1.63.0
-RUN curl https://sh.rustup.rs -sSf | bash -s -- --default-toolchain=1.73 -y
+RUN curl https://sh.rustup.rs -sSf | bash -s -- --default-toolchain=1.89 -y
 ENV PATH="/root/.cargo/bin:${PATH}"
 
 RUN mkdir -p /workspace


### PR DESCRIPTION
Use the current stable version of Rust, that is 1.89.0, since the Rust code used in Milvus does not compile with 1.73.0 anymore.

Fixes #313