### PR TITLE
Support building against system dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,8 +17,9 @@ project(milvus-lite)
 
 option(ENABLE_UNIT_TESTS "Enable unit tests" ON)
 message(STATUS "Enable testing: ${ENABLE_UNIT_TESTS}")
+option(USE_SYSTEM_DEPS "Build with system dependencies rather than Conan" OFF)
 
-list(APPEND CMAKE_MODULE_PATH ${CMAKE_BINARY_DIR}/)
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_BINARY_DIR}/ ${CMAKE_SOURCE_DIR}/cmake)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
@@ -87,11 +88,17 @@ include_directories(${SQLiteCpp_INCLUDE_DIRS})
 find_package(antlr4-runtime REQUIRED)
 include_directories(${antlr4-cppruntime_INCLUDES})
 
-find_package(Protobuf REQUIRED)
-include_directories(${protobuf_INCLUDE_DIRS})
-
+# note: gRPC needs to be included before protobuf when using system dependencies.
 find_package(gRPC REQUIRED)
 include_directories(${gRPC_INCLUDE_DIRS})
+
+find_package(Protobuf REQUIRED)
+if(USE_SYSTEM_DEPS)
+  set(PROTOBUF_LIBRARIES protobuf::libprotobuf)
+else()
+  set(PROTOBUF_LIBRARIES protobuf::protobuf)
+  include_directories(${protobuf_INCLUDE_DIRS})
+endif()
 
 find_package(TBB REQUIRED)
 include_directories(${TBB_tbb_INCLUDE_DIRS})
@@ -118,7 +125,13 @@ find_package(gflags REQUIRED)
 include_directories(${gflags_INCLUDE_DIRS})
 
 find_package(Arrow REQUIRED)
-include_directories(${arrow_INCLUDE_DIRS})
+if(USE_SYSTEM_DEPS)
+  find_package(Parquet REQUIRED)
+  set(ARROW_LIBRARIES Arrow::arrow_shared Parquet::parquet_shared)
+else()
+  set(ARROW_LIBRARIES arrow::arrow)
+  include_directories(${arrow_INCLUDE_DIRS})
+endif()
 
 find_package(re2 REQUIRED)
 include_directories(${re2_INCLUDE_DIRS})
@@ -128,10 +141,21 @@ find_package(double-conversion REQUIRED)
 include_directories(${double-conversion_INCLUDE_DIRS})
 
 find_package(prometheus-cpp REQUIRED)
-include_directories(${prometheus-cpp_INCLUDE_DIRS})
+if(USE_SYSTEM_DEPS)
+  set(PROMETHEUS_CPP_TARGETS prometheus-cpp::pull)
+else()
+  set(PROMETHEUS_CPP_TARGETS prometheus-cpp::prometheus-cpp)
+  include_directories(${prometheus-cpp_INCLUDE_DIRS})
+endif()
 
-find_package(marisa REQUIRED)
-include_directories(${marisa_INCLUDE_DIRS})
+if(USE_SYSTEM_DEPS)
+  find_package(Marisa REQUIRED)
+  set(MARISA_LIBRARIES Marisa::marisa)
+else()
+  find_package(marisa REQUIRED)
+  set(MARISA_LIBRARIES marisa::marisa)
+  include_directories(${marisa_INCLUDE_DIRS})
+endif()
 
 find_package(yaml-cpp REQUIRED)
 include_directories(${yaml-cpp_INCLUDE_DIRS})
@@ -145,7 +169,9 @@ include_directories(${roaring_INCLUDE_DIRS})
 find_package(prometheus-cpp REQUIRED)
 include_directories(${prometheus-cpp_INCLUDE_DIRS})
 
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+if(NOT USE_SYSTEM_DEPS)
+  include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+endif()
 
 FetchContent_Declare(
   simdjson
@@ -352,7 +378,7 @@ target_link_libraries(
   milvus_core
   PUBLIC
   milvus_proto
-  prometheus-cpp::prometheus-cpp
+  ${PROMETHEUS_CPP_TARGET}
   knowhere
 )
 

--- a/cmake/Findantlr4-runtime.cmake
+++ b/cmake/Findantlr4-runtime.cmake
@@ -1,0 +1,2 @@
+FIND_PATH(antlr4-cppruntime_INCLUDES antlr4-runtime.h PATH_SUFFIXES antlr4-runtime REQUIRED)
+FIND_LIBRARY(antlr4-cppruntime_LIBRARIES antlr4-runtime REQUIRED)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -47,10 +47,10 @@ target_link_libraries(
   roaring::roaring
   SQLiteCpp
   ${antlr4-cppruntime_LIBRARIES}
-  marisa::marisa
+  ${MARISA_LIBRARIES}
   TBB::tbb
-  protobuf::protobuf
-  arrow::arrow
+  ${PROTOBUF_LIBRARIES}
+  ${ARROW_LIBRARIES}
   simdjson
   tantivy_binding
 )


### PR DESCRIPTION
Add a `USE_SYSTEM_DEPS` CMake flag and a corresponding environment variable that can be used to build milvus-lite against system libraries while entirely omitting Conan.  This is meant to be an absolutely minimal change, focusing only on the differences between upstream packaging and custom CMake files created by Conan.  This also includes a trivial `Findantlr4-runtime.cmake` module that is necessary since antlr4-runtime does not provide CMake configs.  This changes don't affect the regular build via Conan, and the package still defaults to it.

With these changes and `-DUSE_SYSTEM_DEPS=ON`, I was able to successfully build milvus-lite against the following dependencies:

```
_libgcc_mutex                       0.1              conda_forge            conda-forge
_openmp_mutex                       4.5              2_gnu                  conda-forge
antlr-cpp-runtime                   4.13.2           he02047a_0             conda-forge
attr                                2.5.1            h166bdaf_1             conda-forge
aws-c-auth                          0.7.16           h79b3bcb_6             conda-forge
aws-c-cal                           0.6.10           hb29e0c7_1             conda-forge
aws-c-common                        0.9.13           hd590300_0             conda-forge
aws-c-compression                   0.2.18           hecc5fa9_1             conda-forge
aws-c-event-stream                  0.4.2            hf9b2f7b_4             conda-forge
aws-c-http                          0.8.1            h5d7533a_5             conda-forge
aws-c-io                            0.14.5           h50678d4_1             conda-forge
aws-c-mqtt                          0.10.2           hf479d2b_4             conda-forge
aws-c-s3                            0.5.2            h4ad9680_0             conda-forge
aws-c-sdkutils                      0.1.15           hecc5fa9_1             conda-forge
aws-checksums                       0.1.18           hecc5fa9_1             conda-forge
aws-crt-cpp                         0.26.2           h19f5d62_7             conda-forge
aws-sdk-cpp                         1.11.267         h5606698_1             conda-forge
azure-core-cpp                      1.14.0           h5cfcd09_0             conda-forge
azure-identity-cpp                  1.10.0           h113e628_0             conda-forge
azure-storage-blobs-cpp             12.13.0          h3cf044e_1             conda-forge
azure-storage-common-cpp            12.8.0           h736e048_1             conda-forge
azure-storage-files-datalake-cpp    12.12.0          ha633028_1             conda-forge
binutils_impl_linux-64              2.44             h4bf12b8_1             conda-forge
blas                                2.134            openblas               conda-forge
blas-devel                          3.9.0            34_h1ea3ea9_openblas   conda-forge
bzip2                               1.0.8            h4bc722e_7             conda-forge
c-ares                              1.34.5           hb9d3cd8_0             conda-forge
ca-certificates                     2025.8.3         hbd8a1cb_0             conda-forge
ccache                              4.11.3           h80c52d3_0             conda-forge
cmake                               3.31.6           h74e3db0_0             conda-forge
conda-gcc-specs                     14.3.0           hb991d5c_4             conda-forge
croaring                            4.3.6            hecca717_0             file:///home/mgorny/git/conda/croaring-feedstock/build_artifacts
double-conversion                   3.3.1            h5888daf_0             conda-forge
fmt                                 9.1.0            h924138e_0             conda-forge
folly                               2023.12.25.00    hbc8c634_0_jemalloc    file:///home/mgorny/git/conda/folly-feedstock/build_artifacts
gcc                                 14.3.0           h76bdaa0_4             conda-forge
gcc_impl_linux-64                   14.3.0           hd9e9e21_4             conda-forge
gflags                              2.2.2            h5888daf_1005          conda-forge
gfortran                            14.3.0           he448592_4             conda-forge
gfortran_impl_linux-64              14.3.0           h7db7018_4             conda-forge
glog                                0.6.0            h6f12383_0             conda-forge
gtest                               1.17.0           h84d6215_1             conda-forge
gxx                                 14.3.0           he448592_4             conda-forge
gxx_impl_linux-64                   14.3.0           he663afc_4             conda-forge
icu                                 73.2             h59595ed_0             conda-forge
jemalloc                            5.3.0            h5888daf_1             conda-forge
kernel-headers_linux-64             5.14.0           he073ed8_2             conda-forge
keyutils                            1.6.3            hb9d3cd8_0             conda-forge
krb5                                1.21.3           h659f571_0             conda-forge
ld_impl_linux-64                    2.44             h1423503_1             conda-forge
libabseil                           20230802.1       cxx17_h59595ed_0       conda-forge
libaio                              0.3.113          h166bdaf_0             conda-forge
libarrow                            13.0.0           h5a9302f_27_cpu        conda-forge
libblas                             3.9.0            34_h59b9bed_openblas   conda-forge
libboost                            1.82.0           h6fcfa73_6             conda-forge
libboost-devel                      1.82.0           h00ab1b0_6             conda-forge
libboost-headers                    1.82.0           ha770c72_6             conda-forge
libbrotlicommon                     1.1.0            hb9d3cd8_3             conda-forge
libbrotlidec                        1.1.0            hb9d3cd8_3             conda-forge
libbrotlienc                        1.1.0            hb9d3cd8_3             conda-forge
libcap                              2.71             h39aace5_0             conda-forge
libcblas                            3.9.0            34_he106b2a_openblas   conda-forge
libcrc32c                           1.1.2            h9c3ff4c_0             conda-forge
libcurl                             8.14.1           h332b0f4_0             conda-forge
libedit                             3.1.20250104     pl5321h7949ede_0       conda-forge
libev                               4.33             hd590300_2             conda-forge
libevent                            2.1.12           hf998b51_1             conda-forge
libexpat                            2.7.1            hecca717_0             conda-forge
libffi                              3.4.6            h2dba641_1             conda-forge
libgcc                              15.1.0           h767d61c_4             conda-forge
libgcc-devel_linux-64               14.3.0           h85bb3a7_104           conda-forge
libgcc-ng                           15.1.0           h69a702a_4             conda-forge
libgcrypt-lib                       1.11.1           hb9d3cd8_0             conda-forge
libgfortran                         15.1.0           h69a702a_4             conda-forge
libgfortran-ng                      15.1.0           h69a702a_4             conda-forge
libgfortran5                        15.1.0           hcea5267_4             conda-forge
libgomp                             15.1.0           h767d61c_4             conda-forge
libgoogle-cloud                     2.17.0           h31df0ca_2             conda-forge
libgoogle-cloud-storage             2.17.0           hc7a4891_2             conda-forge
libgpg-error                        1.55             h3f2d84a_0             conda-forge
libgrpc                             1.60.1           h74775cd_0             conda-forge
libhiredis                          1.0.2            h2cc385e_0             conda-forge
libhwloc                            2.11.2           default_he43201b_1000  conda-forge
libiconv                            1.18             h3b78370_2             conda-forge
libjemalloc                         5.3.0            h5888daf_1             conda-forge
liblapack                           3.9.0            34_h7ac8fdf_openblas   conda-forge
liblapacke                          3.9.0            34_he2f377e_openblas   conda-forge
liblzma                             5.8.1            hb9d3cd8_2             conda-forge
liblzma-devel                       5.8.1            hb9d3cd8_2             conda-forge
libnghttp2                          1.64.0           h161d5f1_0             conda-forge
libnl                               3.11.0           hb9d3cd8_0             conda-forge
libnsl                              2.0.1            hb9d3cd8_1             conda-forge
libopenblas                         0.3.30           pthreads_h94d23a6_1    conda-forge
libopentelemetry-cpp                1.14.1           ha162ae1_0             conda-forge
libopentelemetry-cpp-headers        1.14.1           ha770c72_0             conda-forge
libprotobuf                         4.25.1           hf27288f_2             conda-forge
libre2-11                           2023.09.01       h7a70373_1             conda-forge
libsanitizer                        14.3.0           hd08acf3_4             conda-forge
libsodium                           1.0.20           h4ab18f5_0             conda-forge
libsqlite                           3.50.4           h0c1763c_0             conda-forge
libssh2                             1.11.1           hcf80075_0             conda-forge
libstdcxx                           15.1.0           h8f9b012_4             conda-forge
libstdcxx-devel_linux-64            14.3.0           h85bb3a7_104           conda-forge
libstdcxx-ng                        15.1.0           h4852527_4             conda-forge
libsystemd0                         256.9            h2774228_0             conda-forge
libthrift                           0.19.0           hb90f79a_1             conda-forge
libudev1                            257.4            h9a4d06a_0             conda-forge
libutf8proc                         2.8.0            hf23e847_1             conda-forge
libuuid                             2.38.1           h0b41bf4_0             conda-forge
libuv                               1.51.0           hb03c661_1             conda-forge
libxcrypt                           4.4.36           hd590300_1             conda-forge
libxml2                             2.12.7           h4c95cb1_3             conda-forge
libzlib                             1.3.1            hb9d3cd8_2             conda-forge
lz4-c                               1.9.4            hcb278e6_0             conda-forge
ncurses                             6.5              h2d0b736_3             conda-forge
ninja                               1.13.1           h171cf75_0             conda-forge
nlohmann_json                       3.12.0           h3f2d84a_0             conda-forge
openblas                            0.3.30           pthreads_h6ec200e_1    conda-forge
openssl                             3.5.2            h26f9b46_0             conda-forge
orc                                 1.9.2            h7829240_1             conda-forge
pip                                 25.2             pyh8b19718_0           conda-forge
pkgconf                             2.5.1            h73b1eb8_0             conda-forge
prometheus-cpp                      1.2.4            ha5d0236_1             conda-forge
protobuf                            4.25.1           py312h9a107e5_0        conda-forge
python                              3.12.11          h9e4cc4f_0_cpython     conda-forge
python_abi                          3.12             8_cp312                conda-forge
rdma-core                           55.0             h5888daf_0             conda-forge
re2                                 2023.09.01       h7f4b329_1             conda-forge
readline                            8.2              h8c095d6_2             conda-forge
rhash                               1.4.6            hb9d3cd8_1             conda-forge
s2n                                 1.4.5            h06160fa_0             conda-forge
setuptools                          80.9.0           pyhff2d567_0           conda-forge
snappy                              1.1.10           hdb0a2a9_1             conda-forge
sqlitecpp                           3.3.3            h925a8cc_0             conda-forge
sysroot_linux-64                    2.34             h087de78_2             conda-forge
tbb                                 2022.1.0         h4ce085d_0             conda-forge
tbb-devel                           2022.1.0         h1f99690_0             conda-forge
tk                                  8.6.13           noxft_hd72426e_102     conda-forge
tzdata                              2025b            h78e105d_0             conda-forge
ucx                                 1.15.0           ha691c75_8             conda-forge
wheel                               0.45.1           pyhd8ed1ab_1           conda-forge
xz                                  5.8.1            hbcc6ac9_2             conda-forge
xz-gpl-tools                        5.8.1            hbcc6ac9_2             conda-forge
xz-tools                            5.8.1            hb9d3cd8_2             conda-forge
yaml-cpp                            0.8.0            h3f2d84a_0             conda-forge
zlib                                1.3.1            hb9d3cd8_2             conda-forge
zstd                                1.5.7            hb8e6e7a_2             conda-forge
```

Note that I had to build a newer version of `croaring` package, and rebuild `folly` with SSE4.2 enabled.  It is also possible that some of the versions were constrained due to other packages being built against older dependencies at the time.