### PR TITLE
feat(schema): add TIMESTAMPTZ support

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ The command reads rows through `pymilvus` query iterators and writes BulkWriter 
 | Area | Support |
 |---|---|
 | Vector types | `FLOAT_VECTOR`, `SPARSE_FLOAT_VECTOR` |
-| Scalar types | `BOOL`, integer types, `FLOAT`, `DOUBLE`, `VARCHAR`, `JSON`, `ARRAY` |
+| Scalar types | `BOOL`, integer types, `FLOAT`, `DOUBLE`, `VARCHAR`, `JSON`, `ARRAY`, `TIMESTAMPTZ` |
 | Metrics | `COSINE`, `L2`, `IP`, `BM25` |
 | Indexes | `HNSW`, `HNSW_SQ`, `IVF_FLAT`, `IVF_SQ8`, `FLAT`, `BRUTE_FORCE`, `AUTOINDEX`, `SPARSE_INVERTED_INDEX` |
 | CRUD | insert, upsert, partial update, delete by ID/filter, get, query, search, truncate |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -916,7 +916,7 @@ Search → top-N candidates → group by group_by_field → top group_size per g
 | Geometry types | WKT format + spatial queries |
 | Struct/Array nesting | Structured array fields |
 | MinHash vectors | MinHash vector type |
-| TimestampTZ | Timezone-aware timestamps |
+| TimestampTZ timezone hierarchy | Database/collection/query-level timezone overrides for naive timestamp literals |
 | Clustering Key | Clustered compaction |
 | Warmup | Collection pre-warming |
 | MMap | Memory-mapped storage |
@@ -937,6 +937,70 @@ Search → top-N candidates → group by group_by_field → top group_size per g
 | Consistency Levels | Single-process synchronous architecture is naturally Strong Consistency; no need for multiple levels |
 
 **Coverage**: Measured against the Milvus pymilvus test suite (55 test files), MilvusLite P0 covers approximately ~85% of core features, P0+P1 covers approximately ~90%. Remaining gaps are concentrated in advanced index types, extended data types, and enterprise-grade operational capabilities.
+
+---
+
+## Milvus Feature Integration Backlog
+
+This section tracks Milvus features that are worth bringing into MilvusLite after the current compatibility baseline. The selection principle is:
+
+1. Prefer features that improve local development, notebooks, tests, and small-scale RAG applications.
+2. Prefer features that fit the existing LSM + immutable segment architecture.
+3. Prefer pymilvus compatibility gaps that users are likely to hit when moving code between MilvusLite and Milvus.
+4. Avoid distributed, enterprise, and operational-control features that add surface area without improving the embedded use case.
+
+### P0 - High-Value Compatibility and Performance
+
+| Feature | Milvus Surface | Why It Matters | MilvusLite Design Direction | Acceptance Criteria |
+|---|---|---|---|---|
+| Scalar Index | `INVERTED`, `BITMAP`, `NGRAM` scalar indexes | Current scalar filters are functional but can become scan-heavy as local datasets grow. Scalar indexes are the highest-impact performance upgrade because search/query/delete all depend on filters. | Add segment-level immutable `.sidx` files. Filter compilation should first produce an optional indexed bitmap, then merge it with the existing bitmap pipeline. Start with scalar equality/range/in-list indexes, then add NGRAM for `LIKE`/prefix-style VARCHAR predicates. | Indexed and non-indexed filter results are identical under differential tests; large filtered search/query benchmarks show lower scanned-row count. |
+| JSON and Dynamic Field Indexes | JSON path index, dynamic field key index | MilvusLite already supports JSON path and `$meta["key"]` filtering, but those paths likely remain scan-bound. This is a common local RAG metadata pattern. | Reuse the scalar index framework, with extracted path columns stored per segment. Index declared paths first; later consider adaptive path materialization. | Filters such as `meta["source"] == "x"` and `$meta["tenant"] in [...]` can use index bitmaps and preserve current expression semantics. |
+| Compact Vector Types | `FLOAT16_VECTOR`, `BFLOAT16_VECTOR`, `INT8_VECTOR`, `BINARY_VECTOR` | README currently lists binary/float16/bfloat16 vectors as unsupported. These types are important for compatibility and reduce local memory/disk pressure. | Extend schema, Arrow builders, validation, gRPC translators, and distance kernels. Store compact formats natively; convert to float32 for unsupported index/search paths. Start with brute-force parity, then FAISS paths where available. | pymilvus create/insert/search smoke tests pass for each type; distance parity is documented for any conversion path. |
+| IVF_PQ | `IVF_PQ` index | README currently lists Product Quantization as unsupported. FAISS is already a core dependency, so this is a natural index-family extension. | Add `FaissIvfPqIndex` under the existing `VectorIndex` protocol and segment-bound `.idx` lifecycle. Keep `AUTOINDEX` unchanged unless PQ is explicitly requested. | Build/load/search round-trip works; recall benchmark is compared against `BRUTE_FORCE` and existing IVF indexes. |
+
+### P1 - Retrieval Quality and RAG Ergonomics
+
+| Feature | Milvus Surface | Why It Matters | MilvusLite Design Direction | Acceptance Criteria |
+|---|---|---|---|---|
+| Global BM25 Statistics | BM25 sparse search | README notes BM25 IDF is currently segment-local. Cross-segment ranking quality can drift after flushes and compaction. | Maintain collection-level term document-frequency and total-document stats. Update stats during flush/compaction and keep a conservative recovery path. | BM25 results are stable across flush boundaries; differential tests verify segment-local fallback does not change correctness when global stats are unavailable. |
+| Phrase Match | `phrase_match` / text phrase predicates | Phrase search is useful for local document QA and is now part of Milvus text retrieval surface. | Extend the sparse/text inverted index to store term positions. Implement ordered phrase matching with optional slop, then integrate it into filter parsing/evaluation. | `phrase_match(text, "...")` works in query/search filters and matches Milvus-style phrase semantics for supported analyzer output. |
+| Analyzer Debugging | `run_analyzer` | Users building FTS pipelines need to inspect tokenizer/analyzer behavior locally. This is cheap and useful for notebooks. | Expose analyzer execution through the adapter and internal helper API. Reuse existing `Analyzer` implementations. | pymilvus-compatible analyzer debug calls return deterministic token streams for Standard and Jieba analyzers. |
+| Bulk Import | Milvus import / BulkWriter JSON/Parquet inputs | MilvusLite already has dump/export. Import closes the loop for local reproduction of Milvus/Zilliz datasets. | Support Milvus BulkWriter JSON first, then Parquet. Prefer routing through validation + flush to preserve WAL/manifest invariants; direct segment build can be a later optimization. | Export from MilvusLite and import into a fresh MilvusLite DB produces equivalent query/search-visible rows. |
+| Text Highlighting | FTS result highlighting | Useful for search demos and local RAG inspection, but not core storage/search correctness. | Implement as post-processing over output text fields using analyzer token offsets when available. | Search output can include highlight snippets without changing ranking. |
+
+### P2 - Domain-Specific Compatibility
+
+| Feature | Milvus Surface | Why It Matters | MilvusLite Design Direction | Acceptance Criteria |
+|---|---|---|---|---|
+| `TIMESTAMPTZ` follow-ups | Timezone-aware timestamp scalar type | Basic TIMESTAMPTZ storage, UTC normalization, gRPC FieldData, and ISO/INTERVAL filters are implemented. Remaining work is Milvus's timezone hierarchy and index acceleration. | Add database/collection/query-level `timezone` properties for naive timestamp parsing. Later integrate with scalar index or `STL_SORT` equivalent. | Naive timestamp literals respect operation-level timezone precedence; indexed timestamp range filters return the same rows as scan mode. |
+| Geometry | `GEOMETRY`, `ST_*` spatial predicates | Useful for geo-constrained vector search, but domain-specific and optional. | Start with optional `shapely`-backed brute-force predicates. Add segment-level R-tree only if benchmarks justify it. | Geometry fields can be inserted, persisted, and filtered with a small supported subset such as contains/within/intersects. |
+| Binary Vector Indexes | `BIN_FLAT`, `BIN_IVF_FLAT` | Complements `BINARY_VECTOR`; useful for compatibility but less common than float/sparse vectors in RAG. | Add brute-force Hamming/Jaccard first. Add FAISS binary indexes only after storage and metric semantics are stable. | Binary search results match brute-force reference for supported metrics. |
+| SPARSE_WAND | Sparse vector accelerated retrieval | Useful when BM25/sparse collections grow, but depends on sparse index maturity. | Add WAND-style upper-bound pruning inside `SparseInvertedIndex` without changing public API. | Sparse search returns the same top-k as exhaustive sparse scoring on test corpora. |
+| MMap / Warmup | Memory mapped storage, collection pre-warming | Useful for larger local databases, but secondary to indexes and compact vectors. | Introduce only behind explicit collection/index properties. Avoid making mmap a correctness dependency. | Load/search memory profile improves on large read-only datasets without changing results. |
+
+### Reconsider Later
+
+These features are not rejected forever, but should not preempt the P0/P1 work.
+
+| Feature | Reason to Defer |
+|---|---|
+| Full schema alter | Current design assumes immutable schemas. Safe support probably means only additive nullable/default scalar fields first. |
+| Multi-database isolation | Current single default namespace is enough for most local workflows. Full DB isolation adds adapter/storage surface area. |
+| REST API | gRPC/pymilvus compatibility is the primary contract. REST is useful only if there is a concrete local tooling requirement. |
+| Snapshots | Valuable for backup/restore, but direct filesystem copy is often sufficient for embedded usage until concurrent readers/writers become more complex. |
+| DiskANN | Heavy dependency and architecture cost. Revisit only if MilvusLite explicitly targets larger-than-memory local datasets. |
+| SCANN / OPQ / HNSW_PQ | Useful index variants, but IVF_PQ should land first as the quantization baseline. |
+
+### Explicitly Out of Scope for MilvusLite Core
+
+| Feature | Reason |
+|---|---|
+| RBAC, users, roles, privilege groups | Embedded single-user process; security should be handled by the host application. |
+| Resource groups, replicas, shard balancing | Distributed serving controls do not map to a single-process local engine. |
+| Full consistency-level matrix | Single-process synchronous writes naturally provide strong consistency for the embedded use case. Snapshot sequence support should stay internal for iterators/MVCC-style reads. |
+| GPU indexes | Dependency footprint and platform variance are too high for the default local package. |
+| TLS / mTLS | Local embedded deployments should terminate transport security outside MilvusLite if needed. |
+| Distributed metrics / component states | MilvusLite has no QueryNode/DataNode/Coord component topology to report. |
 
 ---
 

--- a/milvus_lite/adapter/grpc/translators/records.py
+++ b/milvus_lite/adapter/grpc/translators/records.py
@@ -8,11 +8,11 @@ without losing any field, type, or null information.
 
 Phase 10.3 supported types (matches translators/schema.py):
     Bool / Int8 / Int16 / Int32 / Int64 / Float / Double / VarChar
-    JSON / FloatVector
+    JSON / Timestamptz / FloatVector
 
 Unsupported (raise UnsupportedFieldTypeError):
     BinaryVector / Float16Vector / BFloat16Vector / SparseFloatVector
-    Int8Vector / Array / Geometry / Text / Timestamptz / ArrayOfVector
+    Int8Vector / Geometry / Text / ArrayOfVector
 
 Two functions:
 
@@ -39,6 +39,7 @@ from pymilvus.grpc_gen import schema_pb2
 
 from milvus_lite.exceptions import SchemaValidationError
 from milvus_lite.schema.types import CollectionSchema, DataType
+from milvus_lite.schema.timestamptz import micros_to_iso_z, parse_timestamptz
 
 
 # ── Milvus DataType enum (int) → name and category. We use the int
@@ -56,6 +57,7 @@ _SCALAR_TYPE_TO_SLOT: Dict[int, str] = {
     11: "double_data",   # Double
     21: "string_data",   # VarChar
     23: "json_data",     # JSON
+    26: "string_data",   # Timestamptz. pymilvus sends/parses it as string_data.
 }
 
 _VECTOR_TYPES = frozenset({100, 101, 102, 103, 104, 105})  # Binary/Float/F16/BF16/Sparse/Int8
@@ -67,6 +69,7 @@ def _milvus_type_name(dtype_int: int) -> str:
         1: "Bool", 2: "Int8", 3: "Int16", 4: "Int32", 5: "Int64",
         10: "Float", 11: "Double", 20: "String", 21: "VarChar",
         22: "Array", 23: "JSON", 24: "Geometry", 25: "Text",
+        26: "Timestamptz",
         100: "BinaryVector", 101: "FloatVector",
         102: "Float16Vector", 103: "BFloat16Vector",
         104: "SparseFloatVector", 105: "Int8Vector",
@@ -193,6 +196,9 @@ def _extract_column(fd, num_rows: int) -> List[Any]:
                 f"expected {num_rows}"
             )
 
+    if dtype_int == 26:
+        column = [None if v is None else parse_timestamptz(v) for v in column]
+
     return column
 
 
@@ -202,6 +208,13 @@ def _extract_scalar_column(fd, dtype_int: int) -> List[Any]:
     # Array type (22) — special handling via array_data slot
     if dtype_int == 22:
         return _extract_array_column(fd)
+
+    if dtype_int == 26:
+        if scalars.HasField("timestamptz_data"):
+            return list(scalars.timestamptz_data.data)
+        if scalars.HasField("string_data"):
+            return list(scalars.string_data.data)
+        return []
 
     if dtype_int not in _SCALAR_TYPE_TO_SLOT:
         raise SchemaValidationError(
@@ -506,6 +519,16 @@ def _build_field_data(name, fschema, column):
         sub.data.extend(encoded)
         return fd
 
+    if dtype == DataType.TIMESTAMPTZ:
+        out = []
+        for v in column:
+            if v is None:
+                out.append("")
+            else:
+                out.append(micros_to_iso_z(v))
+        sub.data.extend(out)
+        return fd
+
     # Numeric / bool / string scalar
     out = []
     for v in column:
@@ -529,6 +552,7 @@ _LITEVECDB_TO_MILVUS_INT: Dict[DataType, int] = {
     DataType.VARCHAR: 21,
     DataType.ARRAY:   22,
     DataType.JSON:    23,
+    DataType.TIMESTAMPTZ: 26,
     DataType.FLOAT_VECTOR: 101,
     DataType.SPARSE_FLOAT_VECTOR: 104,
 }
@@ -540,6 +564,8 @@ def _default_for(dtype: DataType) -> Any:
     if dtype == DataType.BOOL:
         return False
     if dtype in (DataType.INT8, DataType.INT16, DataType.INT32, DataType.INT64):
+        return 0
+    if dtype == DataType.TIMESTAMPTZ:
         return 0
     if dtype in (DataType.FLOAT, DataType.DOUBLE):
         return 0.0
@@ -554,6 +580,8 @@ def _coerce_for(dtype: DataType, v: Any) -> Any:
         return bool(v)
     if dtype in (DataType.INT8, DataType.INT16, DataType.INT32, DataType.INT64):
         return int(v)
+    if dtype == DataType.TIMESTAMPTZ:
+        return parse_timestamptz(v)
     if dtype in (DataType.FLOAT, DataType.DOUBLE):
         return float(v)
     if dtype == DataType.VARCHAR:

--- a/milvus_lite/adapter/grpc/translators/schema.py
+++ b/milvus_lite/adapter/grpc/translators/schema.py
@@ -15,6 +15,7 @@ Type mapping (MilvusLite ↔ Milvus DataType enum):
     VARCHAR      ↔ VarChar (21)
     BOOL         ↔ Bool (1)
     JSON         ↔ JSON (23)
+    TIMESTAMPTZ  ↔ Timestamptz (26)
     FLOAT_VECTOR ↔ FloatVector (101)
 
 Unsupported Milvus types raise UnsupportedFieldTypeError. Phase 10.2 MVP
@@ -46,6 +47,7 @@ from milvus_lite.schema.types import (
     Function,
     FunctionType,
 )
+from milvus_lite.schema.timestamptz import parse_timestamptz
 
 if TYPE_CHECKING:
     pass
@@ -66,6 +68,7 @@ _MILVUS_TO_LITEVECDB: dict[int, DataType] = {
     21: DataType.VARCHAR,        # VarChar
     22: DataType.ARRAY,          # Array
     23: DataType.JSON,           # JSON
+    26: DataType.TIMESTAMPTZ,    # Timestamptz
     101: DataType.FLOAT_VECTOR,          # FloatVector
     104: DataType.SPARSE_FLOAT_VECTOR,  # SparseFloatVector
 }
@@ -92,6 +95,7 @@ _MILVUS_TYPE_NAMES: dict[int, str] = {
     23: "JSON",
     24: "Geometry",
     25: "Text",
+    26: "Timestamptz",
     100: "BinaryVector",
     101: "FloatVector",
     102: "Float16Vector",
@@ -154,7 +158,7 @@ def _decode_field(proto_field: schema_pb2.FieldSchema) -> FieldSchema:
             f"field {proto_field.name!r} uses Milvus type {type_name} "
             f"which MilvusLite does not support. "
             f"Phase 10.2 supports: BOOL, INT8/16/32/64, FLOAT, DOUBLE, "
-            f"VARCHAR, JSON, FLOAT_VECTOR."
+            f"VARCHAR, JSON, ARRAY, TIMESTAMPTZ, FLOAT_VECTOR, SPARSE_FLOAT_VECTOR."
         )
 
     dtype = _MILVUS_TO_LITEVECDB[milvus_dtype_int]
@@ -222,7 +226,7 @@ def _decode_field(proto_field: schema_pb2.FieldSchema) -> FieldSchema:
                 pass
 
     # default_value
-    default_value = _decode_default_value(proto_field)
+    default_value = _decode_default_value(proto_field, dtype)
 
     return FieldSchema(
         name=proto_field.name,
@@ -243,13 +247,19 @@ def _decode_field(proto_field: schema_pb2.FieldSchema) -> FieldSchema:
     )
 
 
-def _decode_default_value(proto_field) -> object | None:
+def _decode_default_value(proto_field, dtype: DataType) -> object | None:
     """Extract default_value from a proto FieldSchema, or None."""
     dv = proto_field.default_value
     which = dv.WhichOneof("data")
     if which is None:
         return None
-    return getattr(dv, which)
+    value = getattr(dv, which)
+    if dtype == DataType.TIMESTAMPTZ:
+        if which in ("long_data", "timestamptz_data"):
+            return int(value)
+        if which == "string_data":
+            return parse_timestamptz(value)
+    return value
 
 
 def _encode_default_value(pf, dtype: DataType, value: object) -> None:
@@ -267,6 +277,11 @@ def _encode_default_value(pf, dtype: DataType, value: object) -> None:
         vd.double_data = float(value)
     elif dtype == DataType.VARCHAR:
         vd.string_data = str(value)
+    elif dtype == DataType.TIMESTAMPTZ:
+        if hasattr(vd, "timestamptz_data"):
+            vd.timestamptz_data = parse_timestamptz(value)
+        else:
+            vd.long_data = parse_timestamptz(value)
 
 
 _MILVUS_FUNCTION_TYPE_MAP = {

--- a/milvus_lite/schema/timestamptz.py
+++ b/milvus_lite/schema/timestamptz.py
@@ -1,0 +1,151 @@
+"""TIMESTAMPTZ normalization helpers.
+
+Milvus stores TIMESTAMPTZ as UTC Unix microseconds on the wire.  The
+engine accepts user-friendly ISO 8601 strings and timezone-aware
+``datetime`` objects, then normalizes them to the same canonical integer.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime, timedelta, timezone
+from typing import Any
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from milvus_lite.exceptions import SchemaValidationError
+
+
+_UTC = timezone.utc
+_EPOCH = datetime(1970, 1, 1, tzinfo=_UTC)
+_INTERVAL_RE = re.compile(
+    r"^P"
+    r"(?:(?P<weeks>\d+(?:\.\d+)?)W)?"
+    r"(?:(?P<days>\d+(?:\.\d+)?)D)?"
+    r"(?:T"
+    r"(?:(?P<hours>\d+(?:\.\d+)?)H)?"
+    r"(?:(?P<minutes>\d+(?:\.\d+)?)M)?"
+    r"(?:(?P<seconds>\d+(?:\.\d+)?)S)?"
+    r")?$",
+    re.IGNORECASE,
+)
+
+
+def parse_timestamptz(value: Any, default_timezone: str | None = None) -> int:
+    """Normalize a TIMESTAMPTZ value to UTC Unix microseconds.
+
+    Accepted inputs:
+    - int: treated as already-normalized UTC microseconds
+    - timezone-aware datetime
+    - ISO 8601 string with an offset or ``Z`` suffix
+
+    Naive strings/datetimes are rejected unless ``default_timezone`` is
+    provided. This leaves room for Milvus-compatible database/collection
+    timezone properties without silently guessing in the MVP.
+    """
+    if isinstance(value, bool):
+        raise SchemaValidationError("TIMESTAMPTZ value must not be bool")
+    if isinstance(value, int):
+        return value
+    if isinstance(value, datetime):
+        return datetime_to_unix_micros(_ensure_aware(value, default_timezone))
+    if isinstance(value, str):
+        return datetime_to_unix_micros(_parse_datetime_string(value, default_timezone))
+    raise SchemaValidationError(
+        f"TIMESTAMPTZ value must be ISO string, aware datetime, or int microseconds; "
+        f"got {type(value).__name__}"
+    )
+
+
+def datetime_to_unix_micros(value: datetime) -> int:
+    """Convert an aware datetime to UTC Unix microseconds."""
+    value = value.astimezone(_UTC)
+    delta = value - _EPOCH
+    return (
+        delta.days * 86_400_000_000
+        + delta.seconds * 1_000_000
+        + delta.microseconds
+    )
+
+
+def micros_to_utc_datetime(value: Any) -> datetime | None:
+    """Convert UTC Unix microseconds or an aware datetime to UTC datetime."""
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return _ensure_aware(value, None).astimezone(_UTC)
+    if isinstance(value, bool) or not isinstance(value, int):
+        value = parse_timestamptz(value)
+    return _EPOCH + timedelta(microseconds=int(value))
+
+
+def micros_to_iso_z(value: Any) -> str | None:
+    """Render a TIMESTAMPTZ value as an ISO 8601 UTC string with ``Z``."""
+    dt = micros_to_utc_datetime(value)
+    if dt is None:
+        return None
+    text = dt.isoformat().replace("+00:00", "Z")
+    if text.endswith(".000000Z"):
+        text = text.replace(".000000Z", "Z")
+    return text
+
+
+def parse_interval_micros(value: str) -> int:
+    """Parse a small ISO 8601 duration subset into microseconds.
+
+    Supported units: weeks, days, hours, minutes, seconds. Calendar
+    years/months are deliberately rejected because their duration depends
+    on a reference date.
+    """
+    if not isinstance(value, str):
+        raise SchemaValidationError("INTERVAL literal must be a string")
+    m = _INTERVAL_RE.match(value)
+    if m is None:
+        raise SchemaValidationError(
+            f"unsupported INTERVAL {value!r}; supported examples: P1D, PT3H, P2DT6H"
+        )
+    parts = {k: float(v) if v is not None else 0.0 for k, v in m.groupdict().items()}
+    if not any(parts.values()) and value.upper() != "P0D":
+        raise SchemaValidationError(
+            f"unsupported INTERVAL {value!r}; supported examples: P1D, PT3H, P2DT6H"
+        )
+    seconds = (
+        parts["weeks"] * 7 * 86_400
+        + parts["days"] * 86_400
+        + parts["hours"] * 3_600
+        + parts["minutes"] * 60
+        + parts["seconds"]
+    )
+    return int(seconds * 1_000_000)
+
+
+def interval_micros_to_timedelta(value: int) -> timedelta:
+    return timedelta(microseconds=int(value))
+
+
+def _parse_datetime_string(value: str, default_timezone: str | None) -> datetime:
+    text = value.strip()
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        dt = datetime.fromisoformat(text)
+    except ValueError as e:
+        raise SchemaValidationError(
+            f"TIMESTAMPTZ value {value!r} is not a valid ISO 8601 timestamp"
+        ) from e
+    return _ensure_aware(dt, default_timezone)
+
+
+def _ensure_aware(value: datetime, default_timezone: str | None) -> datetime:
+    if value.tzinfo is not None and value.utcoffset() is not None:
+        return value
+    if default_timezone is None:
+        raise SchemaValidationError(
+            "TIMESTAMPTZ value must include a timezone offset or use a configured timezone"
+        )
+    try:
+        tz = ZoneInfo(default_timezone)
+    except ZoneInfoNotFoundError as e:
+        raise SchemaValidationError(
+            f"unknown timezone {default_timezone!r}"
+        ) from e
+    return value.replace(tzinfo=tz)

--- a/milvus_lite/schema/types.py
+++ b/milvus_lite/schema/types.py
@@ -20,6 +20,7 @@ class DataType(Enum):
     VARCHAR = "varchar"
     JSON = "json"
     ARRAY = "array"
+    TIMESTAMPTZ = "timestamptz"
     FLOAT_VECTOR = "float_vector"
     SPARSE_FLOAT_VECTOR = "sparse_float_vector"
 
@@ -87,6 +88,7 @@ TYPE_MAP: Dict[DataType, Any] = {
     DataType.VARCHAR: pa.string(),
     DataType.JSON: pa.string(),
     DataType.ARRAY: None,  # resolved at runtime from element_type
+    DataType.TIMESTAMPTZ: pa.timestamp("us", tz="UTC"),
     DataType.FLOAT_VECTOR: None,
     DataType.SPARSE_FLOAT_VECTOR: pa.binary(),
 }

--- a/milvus_lite/schema/validation.py
+++ b/milvus_lite/schema/validation.py
@@ -13,9 +13,22 @@ from milvus_lite.schema.types import (
     Function,
     FunctionType,
 )
+from milvus_lite.schema.timestamptz import parse_timestamptz
 
 # Reserved column names — users may not name fields these.
-RESERVED_FIELD_NAMES = frozenset({"_seq", "_partition", "$meta"})
+#
+# `iso`/`interval` mirror Milvus Plan.g4: they are lexer keywords for
+# TIMESTAMPTZ literals, not identifiers.
+RESERVED_FIELD_NAMES = frozenset({
+    "_seq",
+    "_partition",
+    "$meta",
+    "iso",
+    "ISO",
+    "interval",
+    "INTERVAL",
+})
+_CASE_INSENSITIVE_RESERVED_FIELD_NAMES = frozenset({"iso", "interval"})
 
 # pk dtype must be one of these.
 _PK_ALLOWED_DTYPES = frozenset({DataType.VARCHAR, DataType.INT64})
@@ -32,6 +45,7 @@ _DTYPE_PYTHON_CHECK = {
     DataType.DOUBLE: lambda v: isinstance(v, (int, float)) and not isinstance(v, bool),
     DataType.VARCHAR: lambda v: isinstance(v, str),
     DataType.JSON: lambda v: isinstance(v, (dict, list, str, int, float, bool)) or v is None,
+    DataType.TIMESTAMPTZ: lambda v: isinstance(v, int) and not isinstance(v, bool),
 }
 
 
@@ -49,7 +63,7 @@ def validate_schema(schema: CollectionSchema) -> None:
     - FLOAT_VECTOR field must have dim > 0
     - primary key field must not be nullable
     - field names must be unique
-    - field names must not collide with reserved names (_seq, _partition, $meta)
+    - field names must not collide with reserved names
     - BM25 function: input must be VARCHAR with enable_analyzer,
       output must be SPARSE_FLOAT_VECTOR
     """
@@ -65,7 +79,10 @@ def validate_schema(schema: CollectionSchema) -> None:
     for f in schema.fields:
         if not f.name:
             raise SchemaValidationError("field name must not be empty")
-        if f.name in RESERVED_FIELD_NAMES:
+        if (
+            f.name in RESERVED_FIELD_NAMES
+            or f.name.casefold() in _CASE_INSENSITIVE_RESERVED_FIELD_NAMES
+        ):
             raise SchemaValidationError(
                 f"field name {f.name!r} is reserved (one of {sorted(RESERVED_FIELD_NAMES)})"
             )
@@ -90,6 +107,8 @@ def validate_schema(schema: CollectionSchema) -> None:
                 raise SchemaValidationError(
                     f"ARRAY field {f.name!r} requires element_type"
                 )
+        if f.dtype == DataType.TIMESTAMPTZ and f.default_value is not None:
+            f.default_value = parse_timestamptz(f.default_value)
 
     if len(pk_fields) == 0:
         raise SchemaValidationError("schema has no primary key field")
@@ -375,6 +394,14 @@ def validate_record(record: dict, schema: CollectionSchema) -> None:
                     f"field {f.name!r} is None but not nullable"
                 )
             continue
+        if f.dtype == DataType.TIMESTAMPTZ:
+            try:
+                record[f.name] = parse_timestamptz(value)
+            except SchemaValidationError as e:
+                raise SchemaValidationError(
+                    f"field {f.name!r} value {value!r} does not match dtype {f.dtype}"
+                ) from e
+            value = record[f.name]
         # VARCHAR max_length check
         if f.dtype == DataType.VARCHAR and f.max_length is not None:
             if isinstance(value, str) and len(value) > f.max_length:

--- a/milvus_lite/search/filter/ast.py
+++ b/milvus_lite/search/filter/ast.py
@@ -45,8 +45,22 @@ class BoolLit:
     pos: int
 
 
+@dataclass(frozen=True)
+class TimestampLit:
+    """``ISO '2025-01-01T00:00:00Z'`` TIMESTAMPTZ literal."""
+    value: int  # UTC Unix microseconds
+    pos: int
+
+
+@dataclass(frozen=True)
+class IntervalLit:
+    """``INTERVAL 'P1D'`` duration literal, stored as microseconds."""
+    value: int
+    pos: int
+
+
 # Literal alias for use in ListLit (a list contains only simple literals).
-Literal = Union[IntLit, FloatLit, StringLit, BoolLit]
+Literal = Union[IntLit, FloatLit, StringLit, BoolLit, TimestampLit]
 
 
 @dataclass(frozen=True)
@@ -242,7 +256,7 @@ class ArrayAccessOp:
 # ── Type alias for the union of all node types ──────────────────────────────
 
 Expr = Union[
-    IntLit, FloatLit, StringLit, BoolLit,
+    IntLit, FloatLit, StringLit, BoolLit, TimestampLit, IntervalLit,
     ListLit,
     FieldRef,
     CmpOp, InOp, And, Or, Not,

--- a/milvus_lite/search/filter/eval/arrow_backend.py
+++ b/milvus_lite/search/filter/eval/arrow_backend.py
@@ -27,6 +27,7 @@ from milvus_lite.search.filter.ast import (
     FloatLit,
     InOp,
     IntLit,
+    IntervalLit,
     IsNullOp,
     LikeOp,
     ListLit,
@@ -34,7 +35,9 @@ from milvus_lite.search.filter.ast import (
     Not,
     Or,
     StringLit,
+    TimestampLit,
 )
+from milvus_lite.schema.timestamptz import micros_to_utc_datetime
 
 if TYPE_CHECKING:
     from milvus_lite.search.filter.semantic import CompiledExpr
@@ -119,6 +122,13 @@ def _eval(node, table):
         return pa.scalar(node.value, type=pa.string())
     if isinstance(node, BoolLit):
         return pa.scalar(node.value, type=pa.bool_())
+    if isinstance(node, TimestampLit):
+        return pa.scalar(
+            micros_to_utc_datetime(node.value),
+            type=pa.timestamp("us", tz="UTC"),
+        )
+    if isinstance(node, IntervalLit):
+        return pa.scalar(node.value, type=pa.duration("us"))
 
     if isinstance(node, FieldRef):
         col = table.column(node.name)
@@ -140,7 +150,7 @@ def _eval(node, table):
         # comes from the literals; semantic.py has already verified
         # type compatibility with the field, so pyarrow's auto-cast
         # handles any int/float promotion.
-        py_values = [el.value for el in node.values.elements]
+        py_values = [_eval(el, table).as_py() for el in node.values.elements]
         if not py_values:
             # Empty list: `in []` → all False, `not in []` → all True.
             val = node.negate  # False for `in`, True for `not in`

--- a/milvus_lite/search/filter/eval/python_backend.py
+++ b/milvus_lite/search/filter/eval/python_backend.py
@@ -28,6 +28,7 @@ from milvus_lite.search.filter.ast import (
     FloatLit,
     InOp,
     IntLit,
+    IntervalLit,
     IsNullOp,
     LikeOp,
     ListLit,
@@ -35,11 +36,16 @@ from milvus_lite.search.filter.ast import (
     Not,
     Or,
     StringLit,
+    TimestampLit,
     JsonAccess,
     TextMatchOp,
     ArrayContainsOp,
     ArrayLengthOp,
     ArrayAccessOp,
+)
+from milvus_lite.schema.timestamptz import (
+    interval_micros_to_timedelta,
+    micros_to_utc_datetime,
 )
 
 if TYPE_CHECKING:
@@ -129,6 +135,10 @@ def _eval_row(node, row: dict) -> Any:
         return node.value
     if isinstance(node, BoolLit):
         return node.value
+    if isinstance(node, TimestampLit):
+        return micros_to_utc_datetime(node.value)
+    if isinstance(node, IntervalLit):
+        return interval_micros_to_timedelta(node.value)
 
     if isinstance(node, FieldRef):
         return row.get(node.name)
@@ -149,7 +159,7 @@ def _eval_row(node, row: dict) -> Any:
         val = _eval_row(node.field, row)
         if val is None:
             return None  # NULL propagation (Kleene logic)
-        members = {el.value for el in node.values.elements}
+        members = {_eval_row(el, row) for el in node.values.elements}
         result = val in members
         return (not result) if node.negate else result
 

--- a/milvus_lite/search/filter/parser.py
+++ b/milvus_lite/search/filter/parser.py
@@ -35,6 +35,7 @@ from milvus_lite.search.filter.ast import (
     FloatLit,
     InOp,
     IntLit,
+    IntervalLit,
     ArrayAccessOp,
     ArrayContainsOp,
     ArrayLengthOp,
@@ -47,10 +48,12 @@ from milvus_lite.search.filter.ast import (
     Not,
     Or,
     StringLit,
+    TimestampLit,
     TextMatchOp,
 )
 from milvus_lite.search.filter.exceptions import FilterParseError
 from milvus_lite.search.filter.tokens import Token, TokenKind, tokenize
+from milvus_lite.schema.timestamptz import parse_interval_micros, parse_timestamptz
 
 
 _CMP_KINDS = (
@@ -458,23 +461,14 @@ class Parser:
 
     def parse_primary(self) -> Expr:
         """prec 6: literal | ident | (expr)."""
+        lit = self._parse_literal()
+        if lit is not None:
+            return lit
+
         tok = self._peek()
 
-        if tok.kind == TokenKind.INT:
-            self._consume()
-            return IntLit(value=tok.value, pos=tok.pos)
-
-        if tok.kind == TokenKind.FLOAT:
-            self._consume()
-            return FloatLit(value=tok.value, pos=tok.pos)
-
-        if tok.kind == TokenKind.STRING:
-            self._consume()
-            return StringLit(value=tok.value, pos=tok.pos)
-
-        if tok.kind == TokenKind.BOOL:
-            self._consume()
-            return BoolLit(value=tok.value, pos=tok.pos)
+        if tok.kind == TokenKind.INTERVAL:
+            return self._parse_interval_literal(tok)
 
         if tok.kind == TokenKind.IDENT:
             self._consume()
@@ -530,6 +524,40 @@ class Parser:
             hint="expected literal, identifier, or '('",
         )
 
+    def _parse_timestamp_literal(self, tok: Token) -> Expr:
+        """Parse ``ISO '...'`` as a TIMESTAMPTZ literal."""
+        iso_tok = self._consume()  # ISO
+        value_tok = self._peek()
+        if value_tok.kind != TokenKind.STRING:
+            raise FilterParseError(
+                "ISO timestamp literal requires a string",
+                self.source, value_tok.pos,
+                hint="example: ISO '2025-01-01T00:00:00Z'",
+            )
+        self._consume()
+        try:
+            value = parse_timestamptz(value_tok.value)
+        except Exception as e:
+            raise FilterParseError(str(e), self.source, value_tok.pos) from e
+        return TimestampLit(value=value, pos=iso_tok.pos)
+
+    def _parse_interval_literal(self, tok: Token) -> Expr:
+        """Parse ``INTERVAL 'P1D'`` as a duration literal."""
+        interval_tok = self._consume()  # INTERVAL
+        value_tok = self._peek()
+        if value_tok.kind != TokenKind.STRING:
+            raise FilterParseError(
+                "INTERVAL literal requires a string",
+                self.source, value_tok.pos,
+                hint="example: INTERVAL 'P1D'",
+            )
+        self._consume()
+        try:
+            value = parse_interval_micros(value_tok.value)
+        except Exception as e:
+            raise FilterParseError(str(e), self.source, value_tok.pos) from e
+        return IntervalLit(value=value, pos=interval_tok.pos)
+
     def parse_list_literal(self) -> ListLit:
         """Parse `[ literal (',' literal)* (',')? ]`. Caller has not
         yet consumed the '['."""
@@ -576,6 +604,18 @@ class Parser:
                 return IntLit(value=-inner.value, pos=sub_tok.pos)
             return FloatLit(value=-inner.value, pos=sub_tok.pos)
 
+        lit = self._parse_literal()
+        if lit is not None:
+            return lit
+
+        raise FilterParseError(
+            f"list elements must be literals, got {tok.text!r}",
+            self.source, tok.pos, span=max(1, len(tok.text)),
+        )
+
+    def _parse_literal(self) -> Optional[Literal]:
+        """Parse scalar literals shared by primary expressions and lists."""
+        tok = self._peek()
         if tok.kind == TokenKind.INT:
             self._consume()
             return IntLit(value=tok.value, pos=tok.pos)
@@ -588,11 +628,9 @@ class Parser:
         if tok.kind == TokenKind.BOOL:
             self._consume()
             return BoolLit(value=tok.value, pos=tok.pos)
-
-        raise FilterParseError(
-            f"list elements must be literals, got {tok.text!r}",
-            self.source, tok.pos, span=max(1, len(tok.text)),
-        )
+        if tok.kind == TokenKind.ISO:
+            return self._parse_timestamp_literal(tok)
+        return None
 
     # ── token utilities ─────────────────────────────────────────
 

--- a/milvus_lite/search/filter/semantic.py
+++ b/milvus_lite/search/filter/semantic.py
@@ -27,6 +27,7 @@ from milvus_lite.search.filter.ast import (
     FloatLit,
     InOp,
     IntLit,
+    IntervalLit,
     IsNullOp,
     LikeOp,
     ListLit,
@@ -35,6 +36,7 @@ from milvus_lite.search.filter.ast import (
     Not,
     Or,
     StringLit,
+    TimestampLit,
     JsonAccess,
     TextMatchOp,
     ArrayContainsOp,
@@ -56,12 +58,14 @@ SEM_INT = "int"
 SEM_FLOAT = "float"
 SEM_STRING = "string"
 SEM_BOOL = "bool"
+SEM_TIMESTAMPTZ = "timestamptz"
+SEM_INTERVAL = "interval"
 # Phase F2b: $meta["key"] returns a value whose type is unknown until
 # runtime. SEM_DYNAMIC is compatible with any other type for the purpose
 # of comparisons / IN / arithmetic — runtime semantics decide.
 SEM_DYNAMIC = "dynamic"
 
-_SEM_TYPES = {SEM_INT, SEM_FLOAT, SEM_STRING, SEM_BOOL, SEM_DYNAMIC}
+_SEM_TYPES = {SEM_INT, SEM_FLOAT, SEM_STRING, SEM_BOOL, SEM_TIMESTAMPTZ, SEM_INTERVAL, SEM_DYNAMIC}
 
 # Reserved field names that must not be referenced from filter expressions.
 _RESERVED_FIELDS = frozenset({"_seq", "_partition", "$meta"})
@@ -78,6 +82,8 @@ def _datatype_to_sem(dtype: DataType) -> Optional[str]:
         return SEM_STRING
     if dtype == DataType.BOOL:
         return SEM_BOOL
+    if dtype == DataType.TIMESTAMPTZ:
+        return SEM_TIMESTAMPTZ
     if dtype == DataType.JSON:
         return SEM_STRING  # JSON column is stored as string in Phase F1
     if dtype == DataType.ARRAY:
@@ -93,6 +99,8 @@ def _types_compatible(left: str, right: str) -> bool:
     if left == right:
         return True
     if {left, right} == {SEM_INT, SEM_FLOAT}:
+        return True
+    if left == SEM_TIMESTAMPTZ and right == SEM_TIMESTAMPTZ:
         return True
     if SEM_DYNAMIC in (left, right):
         return True
@@ -300,6 +308,10 @@ def _check_node(node: Expr, ctx: "_CompileCtx") -> str:
         return SEM_STRING
     if isinstance(node, BoolLit):
         return SEM_BOOL
+    if isinstance(node, TimestampLit):
+        return SEM_TIMESTAMPTZ
+    if isinstance(node, IntervalLit):
+        return SEM_INTERVAL
 
     # ── ListLit (only used inside InOp; pure-form is rare) ──────
     if isinstance(node, ListLit):
@@ -397,6 +409,11 @@ def _check_node(node: Expr, ctx: "_CompileCtx") -> str:
     if isinstance(node, ArithOp):
         left_type = _check_node(node.left, ctx)
         right_type = _check_node(node.right, ctx)
+        if node.op in ("+", "-"):
+            if left_type == SEM_TIMESTAMPTZ and right_type == SEM_INTERVAL:
+                return SEM_TIMESTAMPTZ
+            if node.op == "+" and left_type == SEM_INTERVAL and right_type == SEM_TIMESTAMPTZ:
+                return SEM_TIMESTAMPTZ
         # Numeric (int/float) AND dynamic ($meta) are allowed.
         for side, t in (("left", left_type), ("right", right_type)):
             if t not in (SEM_INT, SEM_FLOAT, SEM_DYNAMIC):

--- a/milvus_lite/search/filter/tokens.py
+++ b/milvus_lite/search/filter/tokens.py
@@ -75,6 +75,10 @@ class TokenKind(Enum):
     # Sentinel
     EOF = "EOF"
 
+    # TIMESTAMPTZ literals
+    ISO = "ISO"
+    INTERVAL = "INTERVAL"
+
 
 @dataclass(frozen=True)
 class Token:
@@ -95,6 +99,8 @@ _KEYWORD_MAP = {
     "like": TokenKind.LIKE, "LIKE": TokenKind.LIKE,
     "is": TokenKind.IS, "IS": TokenKind.IS,
     "null": TokenKind.NULL, "NULL": TokenKind.NULL,
+    "iso": TokenKind.ISO, "ISO": TokenKind.ISO,
+    "interval": TokenKind.INTERVAL, "INTERVAL": TokenKind.INTERVAL,
 }
 
 # Boolean literals — only these 6 forms are accepted as bool.

--- a/tests/adapter/test_grpc_timestamptz_milvus_compat.py
+++ b/tests/adapter/test_grpc_timestamptz_milvus_compat.py
@@ -1,0 +1,193 @@
+"""MilvusClient TIMESTAMPTZ compatibility tests.
+
+Migrated and reduced from:
+``~/Workspace/dev/milvus/tests/python_client/milvus_client/test_milvus_client_timestamptz.py``.
+
+MilvusLite currently implements the core TIMESTAMPTZ surface: schema,
+insert/query/search filters, nullable/default values, and UTC
+normalization. Milvus timezone properties, schema evolution, and
+STL_SORT timestamp indexes are tracked as follow-up work in the roadmap
+and intentionally excluded here.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("pymilvus")
+from pymilvus import DataType, MilvusClient  # noqa: E402
+
+
+DIM = 3
+PK = "id"
+VEC = "vector"
+TS = "timestamp"
+
+
+def _schema(nullable: bool = True, default_value=None):
+    schema = MilvusClient.create_schema(auto_id=False, enable_dynamic_field=False)
+    schema.add_field(PK, DataType.INT64, is_primary=True)
+    schema.add_field(VEC, DataType.FLOAT_VECTOR, dim=DIM)
+    schema.add_field(TS, DataType.TIMESTAMPTZ, nullable=nullable, default_value=default_value)
+    return schema
+
+
+def _rows():
+    return [
+        {PK: 0, VEC: [1.0, 2.0, 3.0], TS: "2025-01-01T00:00:00+08:00"},
+        {PK: 1, VEC: [4.0, 5.0, 6.0], TS: "2025-01-03T00:00:00Z"},
+        {PK: 2, VEC: [7.0, 8.0, 9.0], TS: "2024-02-29T00:00:00+03:00"},
+        {PK: 3, VEC: [10.0, 11.0, 12.0], TS: None},
+    ]
+
+
+def _by_id(rows):
+    return {row[PK]: row for row in rows}
+
+
+def test_milvus_client_timestamptz_utc_insert_query(milvus_client):
+    collection = "ts_utc"
+    milvus_client.create_collection(collection, schema=_schema())
+    milvus_client.insert(collection, _rows())
+
+    rows = milvus_client.query(
+        collection,
+        filter=f"{PK} >= 0",
+        output_fields=[PK, TS],
+    )
+
+    got = _by_id(rows)
+    assert got[0][TS] == "2024-12-31T16:00:00Z"
+    assert got[1][TS] == "2025-01-03T00:00:00Z"
+    assert got[2][TS] == "2024-02-28T21:00:00Z"
+    assert got[3][TS] is None
+
+
+def test_milvus_client_timestamptz_query_operators_and_interval(milvus_client):
+    collection = "ts_query"
+    milvus_client.create_collection(collection, schema=_schema())
+    milvus_client.insert(collection, _rows())
+
+    rows = milvus_client.query(
+        collection,
+        filter=f"{TS} >= ISO '2025-01-01T00:00:00Z'",
+        output_fields=[PK, TS],
+    )
+    assert sorted(row[PK] for row in rows) == [1]
+
+    rows = milvus_client.query(
+        collection,
+        filter=f"{TS} <= ISO '2024-12-31T16:00:00Z'",
+        output_fields=[PK, TS],
+    )
+    assert sorted(row[PK] for row in rows) == [0, 2]
+
+    rows = milvus_client.query(
+        collection,
+        filter=f"{TS} != ISO '2025-01-03T00:00:00Z'",
+        output_fields=[PK, TS],
+    )
+    assert sorted(row[PK] for row in rows) == [0, 2]
+
+    rows = milvus_client.query(
+        collection,
+        filter=f"{TS} + INTERVAL 'P1D' <= ISO '2025-01-01T16:00:00Z'",
+        output_fields=[PK, TS],
+    )
+    assert sorted(row[PK] for row in rows) == [0, 2]
+
+    rows = milvus_client.query(
+        collection,
+        filter=f"{TS} is null",
+        output_fields=[PK, TS],
+    )
+    assert rows == [{PK: 3, TS: None}]
+
+
+def test_milvus_client_timestamptz_default_value(milvus_client):
+    collection = "ts_default"
+    milvus_client.create_collection(
+        collection,
+        schema=_schema(default_value="2025-01-01T00:00:00Z"),
+    )
+    milvus_client.insert(collection, [
+        {PK: 0, VEC: [1.0, 2.0, 3.0]},
+        {PK: 1, VEC: [4.0, 5.0, 6.0], TS: None},
+    ])
+
+    rows = milvus_client.query(collection, filter=f"{PK} >= 0", output_fields=[PK, TS])
+    got = _by_id(rows)
+    assert got[0][TS] == "2025-01-01T00:00:00Z"
+    assert got[1][TS] == "2025-01-01T00:00:00Z"
+
+
+def test_milvus_client_timestamptz_search_filter(milvus_client):
+    collection = "ts_search"
+    milvus_client.create_collection(collection, schema=_schema())
+    milvus_client.insert(collection, _rows())
+
+    results = milvus_client.search(
+        collection,
+        data=[[1.0, 2.0, 3.0]],
+        limit=10,
+        filter=f"{TS} <= ISO '2024-12-31T16:00:00Z'",
+        output_fields=[PK, TS],
+    )
+
+    assert len(results) == 1
+    assert sorted(hit["id"] for hit in results[0]) == [0, 2]
+    entities = {hit["id"]: hit["entity"] for hit in results[0]}
+    assert entities[0][TS] == "2024-12-31T16:00:00Z"
+    assert entities[2][TS] == "2024-02-28T21:00:00Z"
+
+
+def test_milvus_client_timestamptz_insert_delete_upsert_flush(milvus_client):
+    collection = "ts_dml"
+    milvus_client.create_collection(collection, schema=_schema())
+    milvus_client.insert(collection, _rows())
+
+    milvus_client.delete(collection, filter=f"{PK} < 2")
+    milvus_client.flush(collection)
+    rows = milvus_client.query(collection, filter=f"{PK} >= 0", output_fields=[PK, TS])
+    assert sorted(row[PK] for row in rows) == [2, 3]
+
+    milvus_client.upsert(collection, [
+        {PK: 0, VEC: [1.0, 1.0, 1.0], TS: "2030-01-01T00:00:00Z"},
+        {PK: 2, VEC: [2.0, 2.0, 2.0], TS: "2030-01-02T00:00:00+08:00"},
+    ])
+    milvus_client.flush(collection)
+
+    rows = milvus_client.query(collection, filter=f"{PK} >= 0", output_fields=[PK, TS])
+    got = _by_id(rows)
+    assert sorted(got) == [0, 2, 3]
+    assert got[0][TS] == "2030-01-01T00:00:00Z"
+    assert got[2][TS] == "2030-01-01T16:00:00Z"
+    assert got[3][TS] is None
+
+
+def test_milvus_client_timestamptz_invalid_time_format(milvus_client):
+    collection = "ts_invalid"
+    milvus_client.create_collection(collection, schema=_schema())
+
+    bad_values = [
+        "invalid_time_format",
+        "2025-04-31T00:00:00Z",
+        "2025-02-29T00:00:00Z",
+        "2025-01-01T00:00:00+24:00",
+    ]
+    for i, value in enumerate(bad_values):
+        with pytest.raises(Exception, match="TIMESTAMPTZ|timestamp|timezone|isoformat|ISO"):
+            milvus_client.insert(collection, [{PK: i, VEC: [1.0, 2.0, 3.0], TS: value}])
+
+
+@pytest.mark.xfail(reason="MilvusLite does not yet implement timezone properties for naive TIMESTAMPTZ values")
+def test_milvus_client_timestamptz_naive_timezone_property_followup(milvus_client):
+    collection = "ts_timezone_followup"
+    milvus_client.create_collection(
+        collection,
+        schema=_schema(),
+        properties={"timezone": "Asia/Shanghai"},
+    )
+    milvus_client.insert(collection, [{PK: 0, VEC: [1.0, 2.0, 3.0], TS: "2025-01-01T00:00:00"}])
+    rows = milvus_client.query(collection, filter=f"{PK} == 0", output_fields=[PK, TS])
+    assert rows[0][TS] == "2024-12-31T16:00:00Z"

--- a/tests/adapter/test_grpc_translators_records.py
+++ b/tests/adapter/test_grpc_translators_records.py
@@ -24,6 +24,7 @@ from milvus_lite.adapter.grpc.translators.records import (
 )
 from milvus_lite.exceptions import SchemaValidationError
 from milvus_lite.schema.types import CollectionSchema, DataType, FieldSchema
+from milvus_lite.schema.timestamptz import micros_to_iso_z, parse_timestamptz
 
 
 # ---------------------------------------------------------------------------
@@ -99,6 +100,20 @@ def test_decode_json_field():
     assert records[0]["data"] == {"k": 1}
     assert records[1]["data"] == {"k": "two"}
     assert records[2]["data"] == [1, 2, 3]
+
+
+def test_decode_timestamptz_field():
+    ts = parse_timestamptz("2025-01-01T00:00:00Z")
+    fd = _scalar_fd("tsz", 26, "string_data", ["2025-01-01T00:00:00Z"])
+    records = fields_data_to_records([fd], num_rows=1)
+    assert records == [{"tsz": ts}]
+
+
+def test_decode_timestamptz_field_from_native_proto_slot():
+    ts = parse_timestamptz("2025-01-01T00:00:00Z")
+    fd = _scalar_fd("tsz", 26, "timestamptz_data", [ts])
+    records = fields_data_to_records([fd], num_rows=1)
+    assert records == [{"tsz": ts}]
 
 
 def test_decode_empty_request():
@@ -214,6 +229,27 @@ def test_encode_basic_round_trip():
     assert records_out[0]["active"] is True
     assert abs(records_out[0]["score"] - 0.5) < 1e-6
     assert records_out[1]["title"] == "b"
+
+
+def test_encode_timestamptz_round_trip():
+    schema = CollectionSchema(fields=[
+        FieldSchema(name="id", dtype=DataType.INT64, is_primary=True),
+        FieldSchema(name="vec", dtype=DataType.FLOAT_VECTOR, dim=2),
+        FieldSchema(name="tsz", dtype=DataType.TIMESTAMPTZ, nullable=True),
+    ])
+    ts = parse_timestamptz("2025-01-01T00:00:00+08:00")
+    fields_data = records_to_fields_data([
+        {"id": 1, "vec": [0.1, 0.2], "tsz": ts},
+        {"id": 2, "vec": [0.2, 0.3], "tsz": None},
+    ], schema)
+    tsz_fd = next(fd for fd in fields_data if fd.field_name == "tsz")
+    assert tsz_fd.type == 26
+    assert list(tsz_fd.valid_data) == [True, False]
+    assert list(tsz_fd.scalars.string_data.data) == [micros_to_iso_z(ts), ""]
+
+    records = fields_data_to_records(fields_data, num_rows=2)
+    assert records[0]["tsz"] == ts
+    assert records[1]["tsz"] is None
 
 
 def test_encode_output_fields_subset():

--- a/tests/adapter/test_grpc_translators_schema.py
+++ b/tests/adapter/test_grpc_translators_schema.py
@@ -35,6 +35,7 @@ def test_round_trip_all_supported_types():
         FieldSchema(name="i16", dtype=DataType.INT16),
         FieldSchema(name="i32", dtype=DataType.INT32),
         FieldSchema(name="data", dtype=DataType.JSON),
+        FieldSchema(name="tsz", dtype=DataType.TIMESTAMPTZ, nullable=True),
     ])
     proto = milvus_lite_to_milvus_schema("test", schema)
     decoded = milvus_to_milvus_lite_schema(proto)
@@ -50,6 +51,7 @@ def test_round_trip_all_supported_types():
     assert by_name["vec"].dim == 128
     # varchar max_length preserved
     assert by_name["title"].max_length == 512
+    assert by_name["tsz"].nullable is True
 
 
 def test_round_trip_dynamic_field_flag():
@@ -215,6 +217,22 @@ def test_round_trip_default_value_int64():
     decoded = milvus_to_milvus_lite_schema(proto)
     by_name = {f.name: f for f in decoded.fields}
     assert by_name["count"].default_value == 0
+
+
+def test_round_trip_default_value_timestamptz():
+    schema = CollectionSchema(fields=[
+        FieldSchema(name="id", dtype=DataType.INT64, is_primary=True),
+        FieldSchema(name="vec", dtype=DataType.FLOAT_VECTOR, dim=4),
+        FieldSchema(
+            name="created_at",
+            dtype=DataType.TIMESTAMPTZ,
+            default_value="2025-01-01T00:00:00Z",
+        ),
+    ])
+    proto = milvus_lite_to_milvus_schema("dv", schema)
+    decoded = milvus_to_milvus_lite_schema(proto)
+    by_name = {f.name: f for f in decoded.fields}
+    assert by_name["created_at"].default_value > 0
 
 
 def test_round_trip_default_value_bool():

--- a/tests/engine/test_timestamptz.py
+++ b/tests/engine/test_timestamptz.py
@@ -1,0 +1,44 @@
+"""TIMESTAMPTZ collection-level behavior."""
+
+from datetime import datetime, timezone
+
+from milvus_lite.engine.collection import Collection
+from milvus_lite.schema.timestamptz import micros_to_utc_datetime
+from milvus_lite.schema.types import CollectionSchema, DataType, FieldSchema
+
+
+def _schema() -> CollectionSchema:
+    return CollectionSchema(fields=[
+        FieldSchema(name="id", dtype=DataType.INT64, is_primary=True),
+        FieldSchema(name="vec", dtype=DataType.FLOAT_VECTOR, dim=2),
+        FieldSchema(name="tsz", dtype=DataType.TIMESTAMPTZ, nullable=True),
+    ])
+
+
+def test_timestamptz_query_and_restart(tmp_path):
+    data_dir = str(tmp_path / "data")
+    col = Collection("events", data_dir, _schema())
+    col.insert([
+        {"id": 1, "vec": [0.1, 0.2], "tsz": "2025-01-01T00:00:00+08:00"},
+        {"id": 2, "vec": [0.2, 0.3], "tsz": "2025-01-03T00:00:00Z"},
+        {"id": 3, "vec": [0.3, 0.4], "tsz": None},
+    ])
+
+    rows = col.query(
+        "tsz > ISO '2025-01-02T00:00:00Z'",
+        output_fields=["id", "tsz"],
+    )
+    assert [r["id"] for r in rows] == [2]
+    assert rows[0]["tsz"] == datetime(2025, 1, 3, tzinfo=timezone.utc)
+
+    rows = col.query(
+        "tsz + INTERVAL 'P1D' <= ISO '2025-01-02T16:00:00Z'",
+        output_fields=["id"],
+    )
+    assert [r["id"] for r in rows] == [1]
+    col.close()
+
+    reopened = Collection("events", data_dir, _schema())
+    got = reopened.get([1], output_fields=["id", "tsz"])
+    assert got[0]["tsz"] == micros_to_utc_datetime("2025-01-01T00:00:00+08:00")
+    reopened.close()

--- a/tests/schema/test_types.py
+++ b/tests/schema/test_types.py
@@ -20,13 +20,14 @@ def test_datatype_values():
     assert DataType.FLOAT_VECTOR.value == "float_vector"
     assert DataType.VARCHAR.value == "varchar"
     assert DataType.JSON.value == "json"
+    assert DataType.TIMESTAMPTZ.value == "timestamptz"
 
 
 def test_datatype_members():
     expected = {
         "BOOL", "INT8", "INT16", "INT32", "INT64",
         "FLOAT", "DOUBLE", "VARCHAR", "JSON", "ARRAY",
-        "FLOAT_VECTOR", "SPARSE_FLOAT_VECTOR",
+        "TIMESTAMPTZ", "FLOAT_VECTOR", "SPARSE_FLOAT_VECTOR",
     }
     assert set(DataType.__members__.keys()) == expected
 
@@ -99,6 +100,7 @@ def test_type_map_scalar_types():
     assert TYPE_MAP[DataType.DOUBLE] == pa.float64()
     assert TYPE_MAP[DataType.VARCHAR] == pa.string()
     assert TYPE_MAP[DataType.JSON] == pa.string()
+    assert TYPE_MAP[DataType.TIMESTAMPTZ] == pa.timestamp("us", tz="UTC")
 
 
 def test_type_map_vector_is_none():

--- a/tests/schema/test_validation.py
+++ b/tests/schema/test_validation.py
@@ -1,6 +1,7 @@
 """Tests for schema/validation.py"""
 
 import json
+from datetime import datetime, timezone
 
 import pytest
 
@@ -18,6 +19,7 @@ from milvus_lite.schema.validation import (
     validate_record,
     validate_schema,
 )
+from milvus_lite.schema.timestamptz import parse_timestamptz
 
 
 # ---------------------------------------------------------------------------
@@ -81,6 +83,16 @@ def test_empty_field_name():
 
 @pytest.mark.parametrize("reserved", sorted(RESERVED_FIELD_NAMES))
 def test_reserved_field_name(reserved):
+    with pytest.raises(SchemaValidationError, match="reserved"):
+        validate_schema(CollectionSchema(fields=[
+            FieldSchema(name="id", dtype=DataType.VARCHAR, is_primary=True),
+            FieldSchema(name=reserved, dtype=DataType.VARCHAR),
+            FieldSchema(name="vec", dtype=DataType.FLOAT_VECTOR, dim=4),
+        ]))
+
+
+@pytest.mark.parametrize("reserved", ["Iso", "iSo", "Interval", "inTERVAL"])
+def test_reserved_field_name_is_case_insensitive(reserved):
     with pytest.raises(SchemaValidationError, match="reserved"):
         validate_schema(CollectionSchema(fields=[
             FieldSchema(name="id", dtype=DataType.VARCHAR, is_primary=True),
@@ -172,6 +184,55 @@ def test_valid_record_ok():
     schema = _basic_schema()
     rec = {"id": "doc1", "vec": [0.1, 0.2, 0.3, 0.4], "title": "hi", "score": 0.5}
     validate_record(rec, schema)
+
+
+def test_timestamptz_record_normalized_to_utc_micros():
+    schema = CollectionSchema(fields=[
+        FieldSchema(name="id", dtype=DataType.INT64, is_primary=True),
+        FieldSchema(name="vec", dtype=DataType.FLOAT_VECTOR, dim=2),
+        FieldSchema(name="tsz", dtype=DataType.TIMESTAMPTZ),
+    ])
+    rec = {
+        "id": 1,
+        "vec": [0.1, 0.2],
+        "tsz": "2025-01-01T00:00:00+08:00",
+    }
+
+    validate_record(rec, schema)
+
+    assert rec["tsz"] == parse_timestamptz("2024-12-31T16:00:00Z")
+
+
+def test_timestamptz_accepts_aware_datetime():
+    schema = CollectionSchema(fields=[
+        FieldSchema(name="id", dtype=DataType.INT64, is_primary=True),
+        FieldSchema(name="vec", dtype=DataType.FLOAT_VECTOR, dim=2),
+        FieldSchema(name="tsz", dtype=DataType.TIMESTAMPTZ),
+    ])
+    rec = {
+        "id": 1,
+        "vec": [0.1, 0.2],
+        "tsz": datetime(2025, 1, 1, tzinfo=timezone.utc),
+    }
+
+    validate_record(rec, schema)
+
+    assert rec["tsz"] == parse_timestamptz("2025-01-01T00:00:00Z")
+
+
+def test_timestamptz_rejects_naive_string():
+    schema = CollectionSchema(fields=[
+        FieldSchema(name="id", dtype=DataType.INT64, is_primary=True),
+        FieldSchema(name="vec", dtype=DataType.FLOAT_VECTOR, dim=2),
+        FieldSchema(name="tsz", dtype=DataType.TIMESTAMPTZ),
+    ])
+
+    with pytest.raises(SchemaValidationError, match="TIMESTAMPTZ"):
+        validate_record({
+            "id": 1,
+            "vec": [0.1, 0.2],
+            "tsz": "2025-01-01T00:00:00",
+        }, schema)
 
 
 def test_record_not_dict():

--- a/tests/search/filter/test_e2e.py
+++ b/tests/search/filter/test_e2e.py
@@ -9,6 +9,7 @@ that introduces python_backend dispatch will preserve semantics.
 """
 
 from dataclasses import replace
+from datetime import datetime, timezone
 
 import pyarrow as pa
 import pytest
@@ -30,6 +31,7 @@ def schema():
         FieldSchema(name="score", dtype=DataType.FLOAT),
         FieldSchema(name="active", dtype=DataType.BOOL),
         FieldSchema(name="category", dtype=DataType.VARCHAR),
+        FieldSchema(name="tsz", dtype=DataType.TIMESTAMPTZ, nullable=True),
     ])
 
 
@@ -43,6 +45,16 @@ def sample_table():
         "score": [0.1, 0.5, 0.7, 0.3, 0.9, 0.5, 1.0, 0.0],
         "active": [True, False, True, True, False, True, True, False],
         "category": ["news", "tech", "tech", "blog", "news", "tech", "ai", "blog"],
+        "tsz": pa.array([
+            datetime(2024, 12, 31, 16, tzinfo=timezone.utc),
+            datetime(2025, 1, 1, 16, tzinfo=timezone.utc),
+            datetime(2025, 1, 2, 16, tzinfo=timezone.utc),
+            None,
+            datetime(2025, 1, 4, 16, tzinfo=timezone.utc),
+            datetime(2025, 1, 5, 16, tzinfo=timezone.utc),
+            datetime(2025, 1, 6, 16, tzinfo=timezone.utc),
+            datetime(2025, 1, 7, 16, tzinfo=timezone.utc),
+        ], type=pa.timestamp("us", tz="UTC")),
     })
 
 
@@ -157,6 +169,12 @@ DIFFERENTIAL_EXPRESSIONS = [
     "age + 1 > 20 and title like '%i%'",
     "title is not null and age * 2 > 30",
     "(age - 10) * 2 < 50 or score / 2 > 0.4",
+    # ── TIMESTAMPTZ ─────────────────────────────────────────────
+    "tsz > ISO '2025-01-03T00:00:00+08:00'",
+    "tsz + INTERVAL 'P1D' <= ISO '2025-01-06T00:00:00Z'",
+    "tsz - INTERVAL 'PT6H' < ISO '2025-01-05T00:00:00Z'",
+    "tsz in [ISO '2025-01-01T16:00:00Z', ISO '2025-01-05T16:00:00Z']",
+    "tsz is null",
 ]
 
 

--- a/tests/search/filter/test_parser.py
+++ b/tests/search/filter/test_parser.py
@@ -11,6 +11,7 @@ from milvus_lite.search.filter.ast import (
     FloatLit,
     InOp,
     IntLit,
+    IntervalLit,
     IsNullOp,
     LikeOp,
     ListLit,
@@ -18,6 +19,7 @@ from milvus_lite.search.filter.ast import (
     Not,
     Or,
     StringLit,
+    TimestampLit,
 )
 from milvus_lite.search.filter.exceptions import FilterParseError
 from milvus_lite.search.filter.parser import parse_expr
@@ -62,6 +64,18 @@ def test_bool_literal_true():
     e = parse_expr("true")
     assert isinstance(e, BoolLit)
     assert e.value is True
+
+
+def test_timestamp_literal():
+    e = parse_expr("ISO '2025-01-01T00:00:00Z'")
+    assert isinstance(e, TimestampLit)
+    assert e.value > 0
+
+
+def test_interval_literal():
+    e = parse_expr("INTERVAL 'P2DT6H'")
+    assert isinstance(e, IntervalLit)
+    assert e.value == (2 * 24 + 6) * 3600 * 1_000_000
 
 
 # ---------------------------------------------------------------------------
@@ -242,6 +256,13 @@ def test_in_trailing_comma():
 def test_in_negative_literal():
     e = parse_expr("temp in [-5, 0, 10]")
     assert [el.value for el in e.values.elements] == [-5, 0, 10]
+
+
+def test_in_timestamp_literal():
+    e = parse_expr("tsz in [ISO '2025-01-01T00:00:00Z']")
+    assert isinstance(e, InOp)
+    assert isinstance(e.values.elements[0], TimestampLit)
+    assert e.values.elements[0].value > 0
 
 
 def test_in_lhs_must_be_field():

--- a/tests/search/filter/test_semantic.py
+++ b/tests/search/filter/test_semantic.py
@@ -19,6 +19,7 @@ def schema():
         FieldSchema(name="score", dtype=DataType.FLOAT),
         FieldSchema(name="active", dtype=DataType.BOOL),
         FieldSchema(name="category", dtype=DataType.VARCHAR),
+        FieldSchema(name="tsz", dtype=DataType.TIMESTAMPTZ, nullable=True),
     ])
 
 
@@ -66,6 +67,11 @@ def test_in_expression(schema):
 
 def test_in_string(schema):
     c = compile_str("category in ['tech', 'news']", schema)
+
+
+def test_in_timestamptz(schema):
+    c = compile_str("tsz in [ISO '2025-01-01T00:00:00Z']", schema)
+    assert "tsz" in c.fields
 
 
 def test_in_empty_list(schema):


### PR DESCRIPTION
Add TIMESTAMPTZ normalization, gRPC translation, ISO/INTERVAL filter literals, and coverage across schema, engine, adapter, and
  search filter paths.