### PR TITLE
feat(schema): add TIMESTAMPTZ support

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ The command reads rows through `pymilvus` query iterators and writes BulkWriter 
 | Area | Support |
 |---|---|
 | Vector types | `FLOAT_VECTOR`, `SPARSE_FLOAT_VECTOR` |
-| Scalar types | `BOOL`, integer types, `FLOAT`, `DOUBLE`, `VARCHAR`, `JSON`, `ARRAY` |
+| Scalar types | `BOOL`, integer types, `FLOAT`, `DOUBLE`, `VARCHAR`, `JSON`, `ARRAY`, `TIMESTAMPTZ` |
 | Metrics | `COSINE`, `L2`, `IP`, `BM25` |
 | Indexes | `HNSW`, `HNSW_SQ`, `IVF_FLAT`, `IVF_SQ8`, `FLAT`, `BRUTE_FORCE`, `AUTOINDEX`, `SPARSE_INVERTED_INDEX` |
 | CRUD | insert, upsert, partial update, delete by ID/filter, get, query, search, truncate |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -916,7 +916,6 @@ Search → top-N candidates → group by group_by_field → top group_size per g
 | Geometry types | WKT format + spatial queries |
 | Struct/Array nesting | Structured array fields |
 | MinHash vectors | MinHash vector type |
-| TimestampTZ | Timezone-aware timestamps |
 | Clustering Key | Clustered compaction |
 | Warmup | Collection pre-warming |
 | MMap | Memory-mapped storage |
@@ -937,6 +936,70 @@ Search → top-N candidates → group by group_by_field → top group_size per g
 | Consistency Levels | Single-process synchronous architecture is naturally Strong Consistency; no need for multiple levels |
 
 **Coverage**: Measured against the Milvus pymilvus test suite (55 test files), MilvusLite P0 covers approximately ~85% of core features, P0+P1 covers approximately ~90%. Remaining gaps are concentrated in advanced index types, extended data types, and enterprise-grade operational capabilities.
+
+---
+
+## Milvus Feature Integration Backlog
+
+This section tracks Milvus features that are worth bringing into MilvusLite after the current compatibility baseline. The selection principle is:
+
+1. Prefer features that improve local development, notebooks, tests, and small-scale RAG applications.
+2. Prefer features that fit the existing LSM + immutable segment architecture.
+3. Prefer pymilvus compatibility gaps that users are likely to hit when moving code between MilvusLite and Milvus.
+4. Avoid distributed, enterprise, and operational-control features that add surface area without improving the embedded use case.
+
+### P0 - High-Value Compatibility and Performance
+
+| Feature | Milvus Surface | Why It Matters | MilvusLite Design Direction | Acceptance Criteria |
+|---|---|---|---|---|
+| Scalar Index | `INVERTED`, `BITMAP`, `NGRAM` scalar indexes | Current scalar filters are functional but can become scan-heavy as local datasets grow. Scalar indexes are the highest-impact performance upgrade because search/query/delete all depend on filters. | Add segment-level immutable `.sidx` files. Filter compilation should first produce an optional indexed bitmap, then merge it with the existing bitmap pipeline. Start with scalar equality/range/in-list indexes, then add NGRAM for `LIKE`/prefix-style VARCHAR predicates. | Indexed and non-indexed filter results are identical under differential tests; large filtered search/query benchmarks show lower scanned-row count. |
+| JSON and Dynamic Field Indexes | JSON path index, dynamic field key index | MilvusLite already supports JSON path and `$meta["key"]` filtering, but those paths likely remain scan-bound. This is a common local RAG metadata pattern. | Reuse the scalar index framework, with extracted path columns stored per segment. Index declared paths first; later consider adaptive path materialization. | Filters such as `meta["source"] == "x"` and `$meta["tenant"] in [...]` can use index bitmaps and preserve current expression semantics. |
+| Compact Vector Types | `FLOAT16_VECTOR`, `BFLOAT16_VECTOR`, `INT8_VECTOR`, `BINARY_VECTOR` | README currently lists binary/float16/bfloat16 vectors as unsupported. These types are important for compatibility and reduce local memory/disk pressure. | Extend schema, Arrow builders, validation, gRPC translators, and distance kernels. Store compact formats natively; convert to float32 for unsupported index/search paths. Start with brute-force parity, then FAISS paths where available. | pymilvus create/insert/search smoke tests pass for each type; distance parity is documented for any conversion path. |
+| IVF_PQ | `IVF_PQ` index | README currently lists Product Quantization as unsupported. FAISS is already a core dependency, so this is a natural index-family extension. | Add `FaissIvfPqIndex` under the existing `VectorIndex` protocol and segment-bound `.idx` lifecycle. Keep `AUTOINDEX` unchanged unless PQ is explicitly requested. | Build/load/search round-trip works; recall benchmark is compared against `BRUTE_FORCE` and existing IVF indexes. |
+
+### P1 - Retrieval Quality and RAG Ergonomics
+
+| Feature | Milvus Surface | Why It Matters | MilvusLite Design Direction | Acceptance Criteria |
+|---|---|---|---|---|
+| Global BM25 Statistics | BM25 sparse search | README notes BM25 IDF is currently segment-local. Cross-segment ranking quality can drift after flushes and compaction. | Maintain collection-level term document-frequency and total-document stats. Update stats during flush/compaction and keep a conservative recovery path. | BM25 results are stable across flush boundaries; differential tests verify segment-local fallback does not change correctness when global stats are unavailable. |
+| Phrase Match | `phrase_match` / text phrase predicates | Phrase search is useful for local document QA and is now part of Milvus text retrieval surface. | Extend the sparse/text inverted index to store term positions. Implement ordered phrase matching with optional slop, then integrate it into filter parsing/evaluation. | `phrase_match(text, "...")` works in query/search filters and matches Milvus-style phrase semantics for supported analyzer output. |
+| Analyzer Debugging | `run_analyzer` | Users building FTS pipelines need to inspect tokenizer/analyzer behavior locally. This is cheap and useful for notebooks. | Expose analyzer execution through the adapter and internal helper API. Reuse existing `Analyzer` implementations. | pymilvus-compatible analyzer debug calls return deterministic token streams for Standard and Jieba analyzers. |
+| Bulk Import | Milvus import / BulkWriter JSON/Parquet inputs | MilvusLite already has dump/export. Import closes the loop for local reproduction of Milvus/Zilliz datasets. | Support Milvus BulkWriter JSON first, then Parquet. Prefer routing through validation + flush to preserve WAL/manifest invariants; direct segment build can be a later optimization. | Export from MilvusLite and import into a fresh MilvusLite DB produces equivalent query/search-visible rows. |
+| Text Highlighting | FTS result highlighting | Useful for search demos and local RAG inspection, but not core storage/search correctness. | Implement as post-processing over output text fields using analyzer token offsets when available. | Search output can include highlight snippets without changing ranking. |
+
+### P2 - Domain-Specific Compatibility
+
+| Feature | Milvus Surface | Why It Matters | MilvusLite Design Direction | Acceptance Criteria |
+|---|---|---|---|---|
+| `TIMESTAMPTZ` follow-ups | Timezone-aware timestamp scalar type | Basic TIMESTAMPTZ storage, UTC normalization, gRPC FieldData, database/collection/request-level timezone parsing, `time_fields`, and ISO/INTERVAL filters are implemented. Remaining work is index acceleration. | Later integrate with scalar index or `STL_SORT` equivalent. | Indexed timestamp range filters return the same rows as scan mode. |
+| Geometry | `GEOMETRY`, `ST_*` spatial predicates | Useful for geo-constrained vector search, but domain-specific and optional. | Start with optional `shapely`-backed brute-force predicates. Add segment-level R-tree only if benchmarks justify it. | Geometry fields can be inserted, persisted, and filtered with a small supported subset such as contains/within/intersects. |
+| Binary Vector Indexes | `BIN_FLAT`, `BIN_IVF_FLAT` | Complements `BINARY_VECTOR`; useful for compatibility but less common than float/sparse vectors in RAG. | Add brute-force Hamming/Jaccard first. Add FAISS binary indexes only after storage and metric semantics are stable. | Binary search results match brute-force reference for supported metrics. |
+| SPARSE_WAND | Sparse vector accelerated retrieval | Useful when BM25/sparse collections grow, but depends on sparse index maturity. | Add WAND-style upper-bound pruning inside `SparseInvertedIndex` without changing public API. | Sparse search returns the same top-k as exhaustive sparse scoring on test corpora. |
+| MMap / Warmup | Memory mapped storage, collection pre-warming | Useful for larger local databases, but secondary to indexes and compact vectors. | Introduce only behind explicit collection/index properties. Avoid making mmap a correctness dependency. | Load/search memory profile improves on large read-only datasets without changing results. |
+
+### Reconsider Later
+
+These features are not rejected forever, but should not preempt the P0/P1 work.
+
+| Feature | Reason to Defer |
+|---|---|
+| Full schema alter | Current design assumes immutable schemas. Safe support probably means only additive nullable/default scalar fields first. |
+| Multi-database isolation | Current single default namespace is enough for most local workflows. Full DB isolation adds adapter/storage surface area. |
+| REST API | gRPC/pymilvus compatibility is the primary contract. REST is useful only if there is a concrete local tooling requirement. |
+| Snapshots | Valuable for backup/restore, but direct filesystem copy is often sufficient for embedded usage until concurrent readers/writers become more complex. |
+| DiskANN | Heavy dependency and architecture cost. Revisit only if MilvusLite explicitly targets larger-than-memory local datasets. |
+| SCANN / OPQ / HNSW_PQ | Useful index variants, but IVF_PQ should land first as the quantization baseline. |
+
+### Explicitly Out of Scope for MilvusLite Core
+
+| Feature | Reason |
+|---|---|
+| RBAC, users, roles, privilege groups | Embedded single-user process; security should be handled by the host application. |
+| Resource groups, replicas, shard balancing | Distributed serving controls do not map to a single-process local engine. |
+| Full consistency-level matrix | Single-process synchronous writes naturally provide strong consistency for the embedded use case. Snapshot sequence support should stay internal for iterators/MVCC-style reads. |
+| GPU indexes | Dependency footprint and platform variance are too high for the default local package. |
+| TLS / mTLS | Local embedded deployments should terminate transport security outside MilvusLite if needed. |
+| Distributed metrics / component states | MilvusLite has no QueryNode/DataNode/Coord component topology to report. |
 
 ---
 

--- a/milvus_lite/adapter/grpc/servicer.py
+++ b/milvus_lite/adapter/grpc/servicer.py
@@ -22,6 +22,7 @@ Implementation discipline (from grpc-adapter-design.md §15):
 from __future__ import annotations
 
 import logging
+import json
 from typing import TYPE_CHECKING
 
 import grpc
@@ -67,6 +68,44 @@ def _extract_anns_field(sub_req) -> str | None:
             except (ValueError, _json.JSONDecodeError):
                 v = kv.value
             return v if isinstance(v, str) and v else None
+    return None
+
+
+def _kv_pairs_to_dict(pairs) -> dict[str, str]:
+    return {
+        str(p.key): str(p.value)
+        for p in pairs
+        if getattr(p, "key", None)
+    }
+
+
+def _dict_to_kv_pairs(values: dict) -> list[common_pb2.KeyValuePair]:
+    return [
+        common_pb2.KeyValuePair(key=str(key), value=str(value))
+        for key, value in values.items()
+    ]
+
+
+def _decode_kv_value(value: str):
+    try:
+        return json.loads(value)
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return value
+
+
+def _extract_timezone(pairs) -> str | None:
+    for kv in pairs:
+        if kv.key == "timezone":
+            value = _decode_kv_value(kv.value)
+            return value if isinstance(value, str) and value else None
+    return None
+
+
+def _extract_time_fields(pairs) -> str | None:
+    for kv in pairs:
+        if kv.key == "time_fields":
+            value = _decode_kv_value(kv.value)
+            return value if isinstance(value, str) and value else None
     return None
 
 
@@ -150,7 +189,12 @@ class MilvusServicer(milvus_pb2_grpc.MilvusServiceServicer):
             proto_schema = schema_pb2.CollectionSchema()
             proto_schema.ParseFromString(request.schema)
             milvus_lite_schema = milvus_to_milvus_lite_schema(proto_schema)
-            self._db.create_collection(request.collection_name, milvus_lite_schema)
+            properties = _kv_pairs_to_dict(getattr(request, "properties", []))
+            self._db.create_collection(
+                request.collection_name,
+                milvus_lite_schema,
+                properties=properties,
+            )
             return common_pb2.Status(**success_status_kwargs())
         except MilvusLiteError as e:
             return common_pb2.Status(**to_status_kwargs(e))
@@ -195,6 +239,7 @@ class MilvusServicer(milvus_pb2_grpc.MilvusServiceServicer):
                 collection_name=col.name,
                 shards_num=1,
                 num_partitions=len(col.list_partitions()),
+                properties=_dict_to_kv_pairs(col.schema.properties),
             )
         except MilvusLiteError as e:
             return milvus_pb2.DescribeCollectionResponse(
@@ -232,7 +277,9 @@ class MilvusServicer(milvus_pb2_grpc.MilvusServiceServicer):
         try:
             col = self._db.get_collection(request.collection_name)
             records = fields_data_to_records(
-                request.fields_data, request.num_rows
+                request.fields_data,
+                request.num_rows,
+                default_timezone=col._effective_timezone(),  # noqa: SLF001
             )
             partition_name = request.partition_name or "_default"
             inserted_pks = col.insert(records, partition_name=partition_name)
@@ -258,7 +305,9 @@ class MilvusServicer(milvus_pb2_grpc.MilvusServiceServicer):
         try:
             col = self._db.get_collection(request.collection_name)
             records = fields_data_to_records(
-                request.fields_data, request.num_rows
+                request.fields_data,
+                request.num_rows,
+                default_timezone=col._effective_timezone(),  # noqa: SLF001
             )
             partition_name = request.partition_name or "_default"
             upserted_pks = col.upsert(records, partition_name=partition_name)
@@ -343,6 +392,8 @@ class MilvusServicer(milvus_pb2_grpc.MilvusServiceServicer):
             # Extract limit and offset from query_params KV list.
             limit = None
             offset = 0
+            timezone = _extract_timezone(request.query_params)
+            time_fields = _extract_time_fields(request.query_params)
             for kv in request.query_params:
                 if kv.key == "limit":
                     try:
@@ -363,7 +414,11 @@ class MilvusServicer(milvus_pb2_grpc.MilvusServiceServicer):
             if output_fields and "count(*)" in output_fields:
                 expr = request.expr if request.expr else None
                 if expr:
-                    rows = col.query(expr, partition_names=partition_names)
+                    rows = col.query(
+                        expr,
+                        partition_names=partition_names,
+                        timezone=timezone,
+                    )
                     count = len(rows)
                 else:
                     count = col.num_entities
@@ -391,12 +446,17 @@ class MilvusServicer(milvus_pb2_grpc.MilvusServiceServicer):
                     partition_names=partition_names,
                     limit=limit,
                     offset=offset,
+                    timezone=timezone,
                 )
 
             return milvus_pb2.QueryResults(
                 status=common_pb2.Status(**success_status_kwargs()),
                 fields_data=records_to_fields_data(
-                    rows, col.schema, output_fields=output_fields,
+                    rows,
+                    col.schema,
+                    output_fields=output_fields,
+                    time_fields=time_fields,
+                    timezone=col._effective_timezone(timezone),  # noqa: SLF001
                 ),
                 collection_name=col.name,
                 output_fields=output_fields or [],
@@ -486,6 +546,7 @@ class MilvusServicer(milvus_pb2_grpc.MilvusServiceServicer):
                 range_filter=parsed.get("range_filter"),
                 offset=search_offset,
                 ranker=parsed.get("ranker"),
+                timezone=parsed.get("timezone"),
             )
 
             if l2_func is not None:
@@ -552,6 +613,8 @@ class MilvusServicer(milvus_pb2_grpc.MilvusServiceServicer):
                 pk_name=col._pk_name,  # noqa: SLF001
                 output_fields=requested_output_fields,
                 group_by_field=group_by_field,
+                time_fields=parsed.get("time_fields"),
+                timezone=col._effective_timezone(parsed.get("timezone")),  # noqa: SLF001
             )
 
             return milvus_pb2.SearchResults(
@@ -929,6 +992,34 @@ class MilvusServicer(milvus_pb2_grpc.MilvusServiceServicer):
             db_names=["default"],
         )
 
+    def DescribeDatabase(self, request, context):
+        try:
+            desc = self._db.describe_database(request.db_name or "default")
+            return milvus_pb2.DescribeDatabaseResponse(
+                status=common_pb2.Status(**success_status_kwargs()),
+                db_name=desc["name"],
+                properties=_dict_to_kv_pairs(desc["properties"]),
+            )
+        except Exception as e:
+            logger.exception("DescribeDatabase failed: %s", e)
+            return milvus_pb2.DescribeDatabaseResponse(
+                status=common_pb2.Status(code=_UNEXPECTED_ERROR, reason=str(e)),
+            )
+
+    def AlterDatabase(self, request, context):
+        try:
+            properties = _kv_pairs_to_dict(getattr(request, "properties", []))
+            delete_keys = list(getattr(request, "delete_keys", [])) or None
+            self._db.alter_database_properties(
+                request.db_name or "default",
+                properties=properties or None,
+                delete_keys=delete_keys,
+            )
+            return common_pb2.Status(**success_status_kwargs())
+        except Exception as e:
+            logger.exception("AlterDatabase failed: %s", e)
+            return common_pb2.Status(code=_UNEXPECTED_ERROR, reason=str(e))
+
     # ── Explicitly UNIMPLEMENTED stubs ─────────────────────────
     #
     # The base class returns UNIMPLEMENTED for every method we don't
@@ -967,6 +1058,10 @@ class MilvusServicer(milvus_pb2_grpc.MilvusServiceServicer):
             top_level_l0_ranker = function_score.get("boost")
             top_level_l2_func = function_score.get("rerank")
             requested_output_fields = list(request.output_fields) or None
+            hybrid_timezone = _extract_timezone(request.rank_params)
+            hybrid_time_fields = _extract_time_fields(request.rank_params)
+            output_timezone = hybrid_timezone
+            output_time_fields = hybrid_time_fields
 
             gb_field = rp.get("group_by_field")
             internal_output_fields = []
@@ -994,6 +1089,11 @@ class MilvusServicer(milvus_pb2_grpc.MilvusServiceServicer):
                     first_spec = next(iter(all_specs.values()), None)
                     sub_default_metric = first_spec.metric_type if first_spec else "COSINE"
                 parsed = parse_search_request(sub_req, default_metric_type=sub_default_metric)
+                route_timezone = parsed.get("timezone") or hybrid_timezone
+                if output_timezone is None and parsed.get("timezone") is not None:
+                    output_timezone = parsed.get("timezone")
+                if output_time_fields is None and parsed.get("time_fields") is not None:
+                    output_time_fields = parsed.get("time_fields")
                 sub_ranker = merge_boost_rankers(
                     parsed.get("ranker"),
                     top_level_l0_ranker,
@@ -1015,6 +1115,7 @@ class MilvusServicer(milvus_pb2_grpc.MilvusServiceServicer):
                     output_fields=route_output_fields,
                     anns_field=parsed.get("anns_field"),
                     ranker=sub_ranker,
+                    timezone=route_timezone,
                 )
                 all_results.append(results)
                 route_metrics.append(parsed["metric_type"])
@@ -1087,6 +1188,8 @@ class MilvusServicer(milvus_pb2_grpc.MilvusServiceServicer):
                 pk_name=col._pk_name,  # noqa: SLF001
                 output_fields=output_fields,
                 group_by_field=gb_field,
+                time_fields=output_time_fields,
+                timezone=col._effective_timezone(output_timezone),  # noqa: SLF001
             )
 
             return milvus_pb2.SearchResults(
@@ -1186,10 +1289,20 @@ class MilvusServicer(milvus_pb2_grpc.MilvusServiceServicer):
             )
 
     def AlterCollection(self, request, context):
-        return self._unimplemented(
-            context, "AlterCollection",
-            "schema is immutable in MilvusLite — create a new collection instead",
-        )
+        try:
+            properties = _kv_pairs_to_dict(getattr(request, "properties", []))
+            delete_keys = list(getattr(request, "delete_keys", [])) or None
+            self._db.alter_collection_properties(
+                request.collection_name,
+                properties=properties or None,
+                delete_keys=delete_keys,
+            )
+            return common_pb2.Status(**success_status_kwargs())
+        except MilvusLiteError as e:
+            return common_pb2.Status(**to_status_kwargs(e))
+        except Exception as e:
+            logger.exception("AlterCollection failed: %s", e)
+            return common_pb2.Status(code=_UNEXPECTED_ERROR, reason=str(e))
 
     def LoadPartitions(self, request, context):
         return self._unimplemented(

--- a/milvus_lite/adapter/grpc/translators/records.py
+++ b/milvus_lite/adapter/grpc/translators/records.py
@@ -8,11 +8,11 @@ without losing any field, type, or null information.
 
 Phase 10.3 supported types (matches translators/schema.py):
     Bool / Int8 / Int16 / Int32 / Int64 / Float / Double / VarChar
-    JSON / FloatVector
+    JSON / Timestamptz / FloatVector
 
 Unsupported (raise UnsupportedFieldTypeError):
     BinaryVector / Float16Vector / BFloat16Vector / SparseFloatVector
-    Int8Vector / Array / Geometry / Text / Timestamptz / ArrayOfVector
+    Int8Vector / Geometry / Text / ArrayOfVector
 
 Two functions:
 
@@ -39,6 +39,11 @@ from pymilvus.grpc_gen import schema_pb2
 
 from milvus_lite.exceptions import SchemaValidationError
 from milvus_lite.schema.types import CollectionSchema, DataType
+from milvus_lite.schema.timestamptz import (
+    extract_time_fields,
+    micros_to_iso_z,
+    parse_timestamptz,
+)
 
 
 # ── Milvus DataType enum (int) → name and category. We use the int
@@ -56,6 +61,7 @@ _SCALAR_TYPE_TO_SLOT: Dict[int, str] = {
     11: "double_data",   # Double
     21: "string_data",   # VarChar
     23: "json_data",     # JSON
+    26: "string_data",   # Timestamptz. pymilvus sends/parses it as string_data.
 }
 
 _VECTOR_TYPES = frozenset({100, 101, 102, 103, 104, 105})  # Binary/Float/F16/BF16/Sparse/Int8
@@ -67,6 +73,7 @@ def _milvus_type_name(dtype_int: int) -> str:
         1: "Bool", 2: "Int8", 3: "Int16", 4: "Int32", 5: "Int64",
         10: "Float", 11: "Double", 20: "String", 21: "VarChar",
         22: "Array", 23: "JSON", 24: "Geometry", 25: "Text",
+        26: "Timestamptz",
         100: "BinaryVector", 101: "FloatVector",
         102: "Float16Vector", 103: "BFloat16Vector",
         104: "SparseFloatVector", 105: "Int8Vector",
@@ -79,6 +86,7 @@ def _milvus_type_name(dtype_int: int) -> str:
 def fields_data_to_records(
     fields_data,
     num_rows: int,
+    default_timezone: str | None = None,
 ) -> List[Dict[str, Any]]:
     """Transpose Milvus columnar fields_data into row-wise records.
 
@@ -102,7 +110,11 @@ def fields_data_to_records(
     records: List[Dict[str, Any]] = [{} for _ in range(num_rows)]
 
     for fd in fields_data:
-        column = _extract_column(fd, num_rows)
+        column = _extract_column(
+            fd,
+            num_rows,
+            default_timezone=default_timezone,
+        )
 
         # Dynamic field handling: pymilvus packs dynamic fields into a
         # single FieldData with is_dynamic=True (or field_name="$meta")
@@ -131,7 +143,11 @@ def fields_data_to_records(
     return records
 
 
-def _extract_column(fd, num_rows: int) -> List[Any]:
+def _extract_column(
+    fd,
+    num_rows: int,
+    default_timezone: str | None = None,
+) -> List[Any]:
     """Pull a single FieldData out as a length-num_rows Python list.
 
     Handles the scalar/vector dispatch, validates length, and
@@ -193,6 +209,15 @@ def _extract_column(fd, num_rows: int) -> List[Any]:
                 f"expected {num_rows}"
             )
 
+    if dtype_int == 26:
+        column = [
+            None if v is None else parse_timestamptz(
+                v,
+                default_timezone=default_timezone,
+            )
+            for v in column
+        ]
+
     return column
 
 
@@ -202,6 +227,13 @@ def _extract_scalar_column(fd, dtype_int: int) -> List[Any]:
     # Array type (22) — special handling via array_data slot
     if dtype_int == 22:
         return _extract_array_column(fd)
+
+    if dtype_int == 26:
+        if scalars.HasField("timestamptz_data"):
+            return list(scalars.timestamptz_data.data)
+        if scalars.HasField("string_data"):
+            return list(scalars.string_data.data)
+        return []
 
     if dtype_int not in _SCALAR_TYPE_TO_SLOT:
         raise SchemaValidationError(
@@ -338,6 +370,8 @@ def records_to_fields_data(
     records: List[Dict[str, Any]],
     schema: CollectionSchema,
     output_fields: Optional[List[str]] = None,
+    time_fields: Optional[List[str] | str] = None,
+    timezone: str | None = None,
 ) -> List:
     """Build columnar FieldData list from row-wise records.
 
@@ -367,12 +401,22 @@ def records_to_fields_data(
         emit_names = [f.name for f in schema.fields if f.name in emit]
 
     field_by_name = {f.name: f for f in schema.fields}
+    time_field_parts = _parse_time_fields(time_fields)
+    time_field_timezone = timezone or schema.properties.get("timezone") or "UTC"
 
     fields_data: List = []
     for fname in emit_names:
         fschema = field_by_name[fname]
         column = [r.get(fname) for r in records]
-        fd = _build_field_data(fname, fschema, column)
+        if fschema.dtype == DataType.TIMESTAMPTZ and time_field_parts:
+            fd = _build_timestamptz_time_fields_data(
+                fname,
+                column,
+                time_field_parts,
+                time_field_timezone,
+            )
+        else:
+            fd = _build_field_data(fname, fschema, column)
         fields_data.append(fd)
 
     # Emit $meta JSON column for dynamic fields.
@@ -398,6 +442,39 @@ def records_to_fields_data(
         fields_data.append(fd)
 
     return fields_data
+
+
+def _parse_time_fields(value: Optional[List[str] | str]) -> List[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        import re
+        return [p for p in re.split(r"[,\s]+", value.strip()) if p]
+    out: List[str] = []
+    for item in value:
+        if isinstance(item, str):
+            out.extend(_parse_time_fields(item))
+    return out
+
+
+def _build_timestamptz_time_fields_data(
+    name: str,
+    column: List[Any],
+    time_fields: List[str],
+    timezone: str,
+):
+    fd = schema_pb2.FieldData()
+    fd.field_name = name
+    fd.type = 22  # Array
+    has_nulls = any(v is None for v in column)
+    if has_nulls:
+        fd.valid_data.extend([v is not None for v in column])
+    fd.scalars.array_data.element_type = 5  # Int64
+    for v in column:
+        row_sf = fd.scalars.array_data.data.add()
+        values = extract_time_fields(v, time_fields, timezone) if v is not None else []
+        row_sf.long_data.data.extend(values or [])
+    return fd
 
 
 def _build_field_data(name, fschema, column):
@@ -506,6 +583,16 @@ def _build_field_data(name, fschema, column):
         sub.data.extend(encoded)
         return fd
 
+    if dtype == DataType.TIMESTAMPTZ:
+        out = []
+        for v in column:
+            if v is None:
+                out.append("")
+            else:
+                out.append(micros_to_iso_z(v))
+        sub.data.extend(out)
+        return fd
+
     # Numeric / bool / string scalar
     out = []
     for v in column:
@@ -529,6 +616,7 @@ _LITEVECDB_TO_MILVUS_INT: Dict[DataType, int] = {
     DataType.VARCHAR: 21,
     DataType.ARRAY:   22,
     DataType.JSON:    23,
+    DataType.TIMESTAMPTZ: 26,
     DataType.FLOAT_VECTOR: 101,
     DataType.SPARSE_FLOAT_VECTOR: 104,
 }
@@ -540,6 +628,8 @@ def _default_for(dtype: DataType) -> Any:
     if dtype == DataType.BOOL:
         return False
     if dtype in (DataType.INT8, DataType.INT16, DataType.INT32, DataType.INT64):
+        return 0
+    if dtype == DataType.TIMESTAMPTZ:
         return 0
     if dtype in (DataType.FLOAT, DataType.DOUBLE):
         return 0.0
@@ -554,6 +644,8 @@ def _coerce_for(dtype: DataType, v: Any) -> Any:
         return bool(v)
     if dtype in (DataType.INT8, DataType.INT16, DataType.INT32, DataType.INT64):
         return int(v)
+    if dtype == DataType.TIMESTAMPTZ:
+        return parse_timestamptz(v)
     if dtype in (DataType.FLOAT, DataType.DOUBLE):
         return float(v)
     if dtype == DataType.VARCHAR:

--- a/milvus_lite/adapter/grpc/translators/result.py
+++ b/milvus_lite/adapter/grpc/translators/result.py
@@ -36,6 +36,8 @@ def build_search_result_data(
     pk_name: str,
     output_fields: Optional[List[str]] = None,
     group_by_field: Optional[str] = None,
+    time_fields: Optional[List[str] | str] = None,
+    timezone: str | None = None,
 ) -> schema_pb2.SearchResultData:
     """Flatten the engine's per-query results into one SearchResultData.
 
@@ -86,7 +88,11 @@ def build_search_result_data(
     # translator still emits one empty FieldData per emitted field
     # (Phase 10.3 fix), so pymilvus's parser doesn't choke.
     fields_data = records_to_fields_data(
-        flat_records, schema, output_fields=output_fields,
+        flat_records,
+        schema,
+        output_fields=output_fields,
+        time_fields=time_fields,
+        timezone=timezone,
     )
 
     # Determine emitted output_fields list. pymilvus's parser uses

--- a/milvus_lite/adapter/grpc/translators/schema.py
+++ b/milvus_lite/adapter/grpc/translators/schema.py
@@ -15,6 +15,7 @@ Type mapping (MilvusLite ↔ Milvus DataType enum):
     VARCHAR      ↔ VarChar (21)
     BOOL         ↔ Bool (1)
     JSON         ↔ JSON (23)
+    TIMESTAMPTZ  ↔ Timestamptz (26)
     FLOAT_VECTOR ↔ FloatVector (101)
 
 Unsupported Milvus types raise UnsupportedFieldTypeError. Phase 10.2 MVP
@@ -46,6 +47,7 @@ from milvus_lite.schema.types import (
     Function,
     FunctionType,
 )
+from milvus_lite.schema.timestamptz import parse_timestamptz
 
 if TYPE_CHECKING:
     pass
@@ -66,6 +68,7 @@ _MILVUS_TO_LITEVECDB: dict[int, DataType] = {
     21: DataType.VARCHAR,        # VarChar
     22: DataType.ARRAY,          # Array
     23: DataType.JSON,           # JSON
+    26: DataType.TIMESTAMPTZ,    # Timestamptz
     101: DataType.FLOAT_VECTOR,          # FloatVector
     104: DataType.SPARSE_FLOAT_VECTOR,  # SparseFloatVector
 }
@@ -92,6 +95,7 @@ _MILVUS_TYPE_NAMES: dict[int, str] = {
     23: "JSON",
     24: "Geometry",
     25: "Text",
+    26: "Timestamptz",
     100: "BinaryVector",
     101: "FloatVector",
     102: "Float16Vector",
@@ -154,7 +158,7 @@ def _decode_field(proto_field: schema_pb2.FieldSchema) -> FieldSchema:
             f"field {proto_field.name!r} uses Milvus type {type_name} "
             f"which MilvusLite does not support. "
             f"Phase 10.2 supports: BOOL, INT8/16/32/64, FLOAT, DOUBLE, "
-            f"VARCHAR, JSON, FLOAT_VECTOR."
+            f"VARCHAR, JSON, ARRAY, TIMESTAMPTZ, FLOAT_VECTOR, SPARSE_FLOAT_VECTOR."
         )
 
     dtype = _MILVUS_TO_LITEVECDB[milvus_dtype_int]
@@ -222,7 +226,7 @@ def _decode_field(proto_field: schema_pb2.FieldSchema) -> FieldSchema:
                 pass
 
     # default_value
-    default_value = _decode_default_value(proto_field)
+    default_value = _decode_default_value(proto_field, dtype)
 
     return FieldSchema(
         name=proto_field.name,
@@ -243,13 +247,19 @@ def _decode_field(proto_field: schema_pb2.FieldSchema) -> FieldSchema:
     )
 
 
-def _decode_default_value(proto_field) -> object | None:
+def _decode_default_value(proto_field, dtype: DataType) -> object | None:
     """Extract default_value from a proto FieldSchema, or None."""
     dv = proto_field.default_value
     which = dv.WhichOneof("data")
     if which is None:
         return None
-    return getattr(dv, which)
+    value = getattr(dv, which)
+    if dtype == DataType.TIMESTAMPTZ:
+        if which in ("long_data", "timestamptz_data"):
+            return int(value)
+        if which == "string_data":
+            return str(value)
+    return value
 
 
 def _encode_default_value(pf, dtype: DataType, value: object) -> None:
@@ -267,6 +277,11 @@ def _encode_default_value(pf, dtype: DataType, value: object) -> None:
         vd.double_data = float(value)
     elif dtype == DataType.VARCHAR:
         vd.string_data = str(value)
+    elif dtype == DataType.TIMESTAMPTZ:
+        if hasattr(vd, "timestamptz_data"):
+            vd.timestamptz_data = parse_timestamptz(value)
+        else:
+            vd.long_data = parse_timestamptz(value)
 
 
 _MILVUS_FUNCTION_TYPE_MAP = {

--- a/milvus_lite/adapter/grpc/translators/search.py
+++ b/milvus_lite/adapter/grpc/translators/search.py
@@ -122,6 +122,12 @@ def parse_search_request(request, default_metric_type: str = "COSINE") -> dict:
         strict_group_size = bool(strict_group_size)
 
     function_score = decode_hybrid_function_score(request.function_score)
+    timezone = raw_params.get("timezone")
+    if not isinstance(timezone, str) or not timezone:
+        timezone = None
+    time_fields = raw_params.get("time_fields")
+    if not isinstance(time_fields, str) or not time_fields:
+        time_fields = None
 
     return {
         "query_vectors": query_vectors,
@@ -141,6 +147,8 @@ def parse_search_request(request, default_metric_type: str = "COSINE") -> dict:
         "round_decimal": int(raw_params.get("round_decimal", -1)),
         "ranker": function_score.get("boost"),
         "rerank": function_score.get("rerank"),
+        "timezone": timezone,
+        "time_fields": time_fields,
     }
 
 

--- a/milvus_lite/db.py
+++ b/milvus_lite/db.py
@@ -40,12 +40,15 @@ from milvus_lite.exceptions import (
 from milvus_lite.schema.persistence import load_schema, save_schema
 from milvus_lite.schema.types import CollectionSchema
 from milvus_lite.schema.validation import validate_schema
+from milvus_lite.schema.timestamptz import validate_timezone_name
 
 
 COLLECTIONS_DIRNAME = "collections"
 LOCK_FILENAME = "LOCK"
 SCHEMA_FILENAME = "schema.json"
 ALIASES_FILENAME = "aliases.json"
+DATABASE_PROPERTIES_FILENAME = "database_properties.json"
+DEFAULT_DATABASE_NAME = "default"
 
 
 class MilvusLite:
@@ -84,6 +87,7 @@ class MilvusLite:
         # only created when explicitly requested (lazy load on get).
         self._collections: Dict[str, Collection] = {}
         self._aliases: Dict[str, str] = self._load_aliases()
+        self._database_properties: Dict[str, Any] = self._load_database_properties()
         self._closed = False
 
     # ── public API ──────────────────────────────────────────────
@@ -92,15 +96,21 @@ class MilvusLite:
         self,
         name: str,
         schema: CollectionSchema,
+        properties: Optional[Dict[str, Any]] = None,
     ) -> Collection:
         """Create a new Collection. Raises if a Collection with this
         name already exists."""
         self._check_open()
         self._validate_name(name)
 
+        if properties:
+            merged = dict(schema.properties)
+            merged.update(properties)
+            schema.properties = merged
+
         # Validate the schema BEFORE touching disk so we don't leave a
         # half-initialized collection directory if validation fails.
-        validate_schema(schema)
+        validate_schema(schema, default_properties=self._database_properties)
 
         if self.has_collection(name):
             raise CollectionAlreadyExistsError(
@@ -115,7 +125,12 @@ class MilvusLite:
         save_schema(schema, name, os.path.join(col_dir, SCHEMA_FILENAME))
 
         try:
-            col = Collection(name, col_dir, schema)
+            col = Collection(
+                name,
+                col_dir,
+                schema,
+                database_properties=self._database_properties,
+            )
         except Exception:
             # Clean up orphan directory if Collection init fails
             shutil.rmtree(col_dir, ignore_errors=True)
@@ -137,7 +152,12 @@ class MilvusLite:
 
         col_dir = self._collection_dir(name)
         _name, schema = load_schema(os.path.join(col_dir, SCHEMA_FILENAME))
-        col = Collection(name, col_dir, schema)
+        col = Collection(
+            name,
+            col_dir,
+            schema,
+            database_properties=self._database_properties,
+        )
         self._collections[name] = col
         return col
 
@@ -250,6 +270,72 @@ class MilvusLite:
         os.makedirs(col_dir, exist_ok=False)
         save_schema(schema, name, os.path.join(col_dir, SCHEMA_FILENAME))
 
+    def alter_collection_properties(
+        self,
+        name: str,
+        properties: Optional[Dict[str, Any]] = None,
+        delete_keys: Optional[List[str]] = None,
+    ) -> None:
+        """Update mutable collection properties and persist schema.json."""
+        self._check_open()
+        name = self.resolve_collection_name(name)
+        if not self.has_collection(name):
+            raise CollectionNotFoundError(f"collection {name!r} does not exist")
+
+        col = self.get_collection(name)
+        col.alter_properties(properties=properties, delete_keys=delete_keys)
+        save_schema(
+            col.schema,
+            name,
+            os.path.join(self._collection_dir(name), SCHEMA_FILENAME),
+        )
+
+    def describe_database(self, name: str = DEFAULT_DATABASE_NAME) -> Dict[str, Any]:
+        """Return metadata for the single embedded database."""
+        self._check_open()
+        self._validate_database_name(name)
+        return {
+            "name": DEFAULT_DATABASE_NAME,
+            "properties": dict(self._database_properties),
+        }
+
+    def alter_database_properties(
+        self,
+        name: str = DEFAULT_DATABASE_NAME,
+        properties: Optional[Dict[str, Any]] = None,
+        delete_keys: Optional[List[str]] = None,
+    ) -> None:
+        """Update database-level default properties.
+
+        MilvusLite exposes one embedded database named ``default``.  Its
+        properties are defaults for collections that do not set the same
+        property themselves; TIMESTAMPTZ timezone parsing currently uses
+        this hierarchy.
+        """
+        self._check_open()
+        self._validate_database_name(name)
+
+        next_props = dict(self._database_properties)
+        for key in delete_keys or []:
+            next_props.pop(str(key), None)
+        for key, value in (properties or {}).items():
+            next_props[str(key)] = value
+        next_props = self._normalize_database_properties(next_props)
+
+        self._database_properties.clear()
+        self._database_properties.update(next_props)
+        self._save_database_properties()
+        for col in self._collections.values():
+            col._filter_cache.clear()  # noqa: SLF001
+
+    def drop_database_properties(
+        self,
+        name: str = DEFAULT_DATABASE_NAME,
+        property_keys: Optional[List[str]] = None,
+    ) -> None:
+        """Delete database-level properties."""
+        self.alter_database_properties(name=name, delete_keys=property_keys or [])
+
     def create_alias(self, collection_name: str, alias: str) -> None:
         """Create a collection alias."""
         self._check_open()
@@ -360,6 +446,9 @@ class MilvusLite:
     def _aliases_path(self) -> str:
         return os.path.join(self._data_dir, ALIASES_FILENAME)
 
+    def _database_properties_path(self) -> str:
+        return os.path.join(self._data_dir, DATABASE_PROPERTIES_FILENAME)
+
     def _load_aliases(self) -> Dict[str, str]:
         path = self._aliases_path()
         if not os.path.exists(path):
@@ -380,6 +469,45 @@ class MilvusLite:
         with open(tmp_path, "w", encoding="utf-8") as f:
             json.dump(self._aliases, f, ensure_ascii=False, indent=2, sort_keys=True)
         os.replace(tmp_path, path)
+
+    def _load_database_properties(self) -> Dict[str, Any]:
+        path = self._database_properties_path()
+        if not os.path.exists(path):
+            return {}
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            return {}
+        return self._normalize_database_properties(data)
+
+    def _save_database_properties(self) -> None:
+        path = self._database_properties_path()
+        tmp_path = path + ".tmp"
+        with open(tmp_path, "w", encoding="utf-8") as f:
+            json.dump(
+                self._database_properties,
+                f,
+                ensure_ascii=False,
+                indent=2,
+                sort_keys=True,
+            )
+        os.replace(tmp_path, path)
+
+    @staticmethod
+    def _normalize_database_properties(values: Dict[str, Any]) -> Dict[str, Any]:
+        out = {str(key): value for key, value in values.items()}
+        if "timezone" in out:
+            out["timezone"] = validate_timezone_name(out["timezone"])
+        return out
+
+    @staticmethod
+    def _validate_database_name(name: str) -> None:
+        if not name:
+            name = DEFAULT_DATABASE_NAME
+        if name != DEFAULT_DATABASE_NAME:
+            raise ValueError(
+                f"MilvusLite only supports database {DEFAULT_DATABASE_NAME!r}, got {name!r}"
+            )
 
     @staticmethod
     def _validate_name(name: str) -> None:

--- a/milvus_lite/engine/collection.py
+++ b/milvus_lite/engine/collection.py
@@ -70,6 +70,7 @@ from milvus_lite.schema.validation import (
     validate_record,
     validate_schema,
 )
+from milvus_lite.schema.timestamptz import validate_timezone_name
 from milvus_lite.search.assembler import assemble_candidates
 from milvus_lite.search.executor import execute_search
 from milvus_lite.search.executor_indexed import execute_search_with_index
@@ -145,8 +146,12 @@ class Collection:
         name: str,
         data_dir: str,
         schema: CollectionSchema,
+        database_properties: Optional[Dict[str, Any]] = None,
     ) -> None:
-        validate_schema(schema)
+        self._database_properties = (
+            database_properties if database_properties is not None else {}
+        )
+        validate_schema(schema, default_properties=self._database_properties)
 
         self._name = name
         self._data_dir = data_dir
@@ -311,7 +316,11 @@ class Collection:
 
         # 3. validate every record up-front
         for r in records:
-            validate_record(r, self._schema)
+            validate_record(
+                r,
+                self._schema,
+                default_properties=self._database_properties,
+            )
 
         # 4. partition key routing
         if self._partition_key_field is not None:
@@ -504,6 +513,7 @@ class Collection:
         partition_names: Optional[List[str]] = None,
         expr: Optional[str] = None,
         output_fields: Optional[List[str]] = None,
+        timezone: Optional[str] = None,
     ) -> List[dict]:
         """Point read across MemTable + segments.
 
@@ -526,7 +536,7 @@ class Collection:
         self._require_loaded()
 
         partition_filter = set(partition_names) if partition_names else None
-        compiled_filter = self._compile_filter(expr) if expr else None
+        compiled_filter = self._compile_filter(expr, timezone=timezone) if expr else None
         # Snapshot tombstones so the bg worker's gc_below doesn't
         # invalidate entries we rely on during this read.
         seg_snap, delta_snap = self._read_snapshot()
@@ -591,6 +601,7 @@ class Collection:
         range_filter: Optional[float] = None,
         offset: int = 0,
         ranker: Optional[dict] = None,
+        timezone: Optional[str] = None,
     ) -> List[List[dict]]:
         """Vector top-k search.
 
@@ -684,6 +695,7 @@ class Collection:
                 partition_names=partition_names,
                 expr=expr,
                 output_fields=output_fields,
+                timezone=timezone,
             )
         else:
             # Dense float vector search — auto-embed text queries if needed
@@ -693,7 +705,7 @@ class Collection:
                 raise ValueError(
                     f"query_vectors must be a 2-D list, got shape {q_arr.shape}"
                 )
-            compiled_filter = self._compile_filter(expr) if expr else None
+            compiled_filter = self._compile_filter(expr, timezone=timezone) if expr else None
             seg_snap, delta_snap = self._read_snapshot()
             raw_results = execute_search_with_index(
                 query_vectors=q_arr,
@@ -725,7 +737,7 @@ class Collection:
                 ranker,
                 metric_type=metric_type,
                 pk_name=self._pk_name,
-                compile_filter=self._compile_filter,
+                compile_filter=lambda s: self._compile_filter(s, timezone=timezone),
                 row_matches_filter=_row_matches_filter,
             )
 
@@ -786,6 +798,7 @@ class Collection:
         partition_names: Optional[List[str]],
         expr: Optional[str],
         output_fields: Optional[List[str]],
+        timezone: Optional[str] = None,
     ) -> List[List[dict]]:
         """Sparse vector search using per-segment cached BM25 indexes.
 
@@ -880,7 +893,7 @@ class Collection:
 
             # Apply scalar filter
             if expr:
-                compiled = self._compile_filter(expr)
+                compiled = self._compile_filter(expr, timezone=timezone)
                 from milvus_lite.search.filter.eval import evaluate as filter_evaluate
                 fmask = filter_evaluate(compiled, table).to_numpy(zero_copy_only=False)
                 valid_mask = valid_mask & fmask
@@ -918,7 +931,7 @@ class Collection:
             mt_valid = np.ones(len(mt_pks), dtype=bool)
 
             if expr:
-                compiled = self._compile_filter(expr)
+                compiled = self._compile_filter(expr, timezone=timezone)
                 from milvus_lite.search.filter.eval.python_backend import _eval_row
                 for i in range(len(mt_pks)):
                     if mt_valid[i]:
@@ -1053,6 +1066,7 @@ class Collection:
         partition_names: Optional[List[str]] = None,
         limit: Optional[int] = None,
         offset: int = 0,
+        timezone: Optional[str] = None,
     ) -> List[dict]:
         """Pure scalar query — no vector, no distance.
 
@@ -1079,7 +1093,7 @@ class Collection:
 
         self._require_loaded()
 
-        compiled_filter = self._compile_filter(expr) if expr else None
+        compiled_filter = self._compile_filter(expr, timezone=timezone) if expr else None
 
         seg_snap, delta_snap = self._read_snapshot()
 
@@ -1138,20 +1152,38 @@ class Collection:
                 f"call load() before search/get/query"
             )
 
-    def _compile_filter(self, expr_str: str) -> "CompiledExpr":
+    def _compile_filter(
+        self,
+        expr_str: str,
+        timezone: Optional[str] = None,
+    ) -> "CompiledExpr":
         """Parse + compile a filter expression, with LRU caching.
 
-        The cache is keyed only on the expression string because the
-        schema is implicit (this Collection's). Schema is immutable for
-        the lifetime of a Collection, so cached entries never go stale.
+        The cache is keyed on the expression string plus the effective
+        timezone, because naive TIMESTAMPTZ literals are normalized at
+        parse time.
         """
-        cached = self._filter_cache.get(expr_str)
+        default_timezone = self._effective_timezone(timezone)
+        cache_key = (expr_str, default_timezone)
+        cached = self._filter_cache.get(cache_key)
         if cached is not None:
             return cached
         from milvus_lite.search.filter import compile_filter
-        compiled = compile_filter(expr_str, self._schema)
-        self._filter_cache.put(expr_str, compiled)
+        compiled = compile_filter(
+            expr_str,
+            self._schema,
+            default_timezone=default_timezone,
+        )
+        self._filter_cache.put(cache_key, compiled)
         return compiled
+
+    def _effective_timezone(self, timezone: Optional[str] = None) -> Optional[str]:
+        if timezone is not None and timezone != "":
+            return validate_timezone_name(timezone)
+        return (
+            self._schema.properties.get("timezone")
+            or self._database_properties.get("timezone")
+        )
 
     def _project_record(
         self,
@@ -1500,6 +1532,30 @@ class Collection:
         """Collection schema (read-only)."""
         return self._schema
 
+    def alter_properties(
+        self,
+        properties: Optional[Dict[str, Any]] = None,
+        delete_keys: Optional[List[str]] = None,
+    ) -> None:
+        """Update mutable collection properties.
+
+        The schema structure remains immutable; only schema-level
+        properties such as TIMESTAMPTZ timezone are updated.
+        """
+        import copy
+
+        next_schema = copy.deepcopy(self._schema)
+        next_props = dict(next_schema.properties)
+        for key in delete_keys or []:
+            next_props.pop(str(key), None)
+        for key, value in (properties or {}).items():
+            next_props[str(key)] = value
+        next_schema.properties = next_props
+        validate_schema(next_schema, default_properties=self._database_properties)
+
+        self._schema.properties = dict(next_schema.properties)
+        self._filter_cache.clear()
+
     @property
     def num_entities(self) -> int:
         """Approximate live row count across MemTable + segments.
@@ -1579,6 +1635,7 @@ class Collection:
                     for f in self._schema.fields
                 ],
                 "enable_dynamic_field": self._schema.enable_dynamic_field,
+                "properties": dict(self._schema.properties),
             },
             "partitions": self.list_partitions(),
             "num_entities": self.num_entities,

--- a/milvus_lite/schema/persistence.py
+++ b/milvus_lite/schema/persistence.py
@@ -6,6 +6,7 @@ Format (one schema = one JSON file):
       "collection_name": "...",
       "version": 1,
       "enable_dynamic_field": false,
+      "properties": {},
       "fields": [
         {
           "name": "id",
@@ -57,6 +58,7 @@ def save_schema(
         "schema_format_version": SCHEMA_FORMAT_VERSION,
         "version": schema.version,
         "enable_dynamic_field": schema.enable_dynamic_field,
+        "properties": dict(schema.properties),
         "fields": [_field_to_dict(f) for f in schema.fields],
     }
     if schema.functions:
@@ -98,6 +100,7 @@ def load_schema(path: str) -> Tuple[str, CollectionSchema]:
         collection_name = payload["collection_name"]
         version = payload["version"]
         enable_dynamic = payload.get("enable_dynamic_field", False)
+        properties = payload.get("properties", {})
         fields_raw = payload["fields"]
     except KeyError as e:
         raise SchemaValidationError(
@@ -107,6 +110,10 @@ def load_schema(path: str) -> Tuple[str, CollectionSchema]:
     if not isinstance(fields_raw, list):
         raise SchemaValidationError(
             f"schema file {path!r} 'fields' must be a list"
+        )
+    if not isinstance(properties, dict):
+        raise SchemaValidationError(
+            f"schema file {path!r} 'properties' must be an object"
         )
 
     fields = [_field_from_dict(d, path) for d in fields_raw]
@@ -119,6 +126,7 @@ def load_schema(path: str) -> Tuple[str, CollectionSchema]:
         version=int(version),
         enable_dynamic_field=bool(enable_dynamic),
         functions=functions,
+        properties=dict(properties) if isinstance(properties, dict) else {},
     )
     return str(collection_name), schema
 

--- a/milvus_lite/schema/timestamptz.py
+++ b/milvus_lite/schema/timestamptz.py
@@ -1,0 +1,197 @@
+"""TIMESTAMPTZ normalization helpers.
+
+Milvus stores TIMESTAMPTZ as UTC Unix microseconds on the wire.  The
+engine accepts user-friendly ISO 8601 strings and timezone-aware
+``datetime`` objects, then normalizes them to the same canonical integer.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime, timedelta, timezone
+from typing import Any
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from milvus_lite.exceptions import SchemaValidationError
+
+
+_UTC = timezone.utc
+_EPOCH = datetime(1970, 1, 1, tzinfo=_UTC)
+_INTERVAL_RE = re.compile(
+    r"^P"
+    r"(?:(?P<weeks>\d+(?:\.\d+)?)W)?"
+    r"(?:(?P<days>\d+(?:\.\d+)?)D)?"
+    r"(?:T"
+    r"(?:(?P<hours>\d+(?:\.\d+)?)H)?"
+    r"(?:(?P<minutes>\d+(?:\.\d+)?)M)?"
+    r"(?:(?P<seconds>\d+(?:\.\d+)?)S)?"
+    r")?$",
+    re.IGNORECASE,
+)
+
+
+def parse_timestamptz(value: Any, default_timezone: str | None = None) -> int:
+    """Normalize a TIMESTAMPTZ value to UTC Unix microseconds.
+
+    Accepted inputs:
+    - int: treated as already-normalized UTC microseconds
+    - timezone-aware datetime
+    - ISO 8601 string with an offset or ``Z`` suffix
+
+    Naive strings/datetimes are rejected unless ``default_timezone`` is
+    provided by collection/request timezone properties.
+    """
+    if isinstance(value, bool):
+        raise SchemaValidationError("TIMESTAMPTZ value must not be bool")
+    if isinstance(value, int):
+        return value
+    if isinstance(value, datetime):
+        return datetime_to_unix_micros(_ensure_aware(value, default_timezone))
+    if isinstance(value, str):
+        return datetime_to_unix_micros(_parse_datetime_string(value, default_timezone))
+    raise SchemaValidationError(
+        f"TIMESTAMPTZ value must be ISO string, aware datetime, or int microseconds; "
+        f"got {type(value).__name__}"
+    )
+
+
+def validate_timezone_name(value: Any) -> str:
+    """Validate and normalize a collection/request timezone property."""
+    if not isinstance(value, str) or not value:
+        raise SchemaValidationError("timezone property must be a non-empty string")
+    try:
+        ZoneInfo(value)
+    except ZoneInfoNotFoundError as e:
+        raise SchemaValidationError(f"unknown timezone {value!r}") from e
+    return value
+
+
+def datetime_to_unix_micros(value: datetime) -> int:
+    """Convert an aware datetime to UTC Unix microseconds."""
+    value = value.astimezone(_UTC)
+    delta = value - _EPOCH
+    return (
+        delta.days * 86_400_000_000
+        + delta.seconds * 1_000_000
+        + delta.microseconds
+    )
+
+
+def micros_to_utc_datetime(value: Any) -> datetime | None:
+    """Convert UTC Unix microseconds or an aware datetime to UTC datetime."""
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return _ensure_aware(value, None).astimezone(_UTC)
+    if isinstance(value, bool) or not isinstance(value, int):
+        value = parse_timestamptz(value)
+    return _EPOCH + timedelta(microseconds=int(value))
+
+
+def micros_to_iso_z(value: Any) -> str | None:
+    """Render a TIMESTAMPTZ value as an ISO 8601 UTC string with ``Z``."""
+    dt = micros_to_utc_datetime(value)
+    if dt is None:
+        return None
+    text = dt.isoformat().replace("+00:00", "Z")
+    if text.endswith(".000000Z"):
+        text = text.replace(".000000Z", "Z")
+    return text
+
+
+def extract_time_fields(
+    value: Any,
+    fields: list[str],
+    timezone_name: str = "UTC",
+) -> list[int] | None:
+    """Extract TIMESTAMPTZ components in the requested timezone."""
+    dt = micros_to_utc_datetime(value)
+    if dt is None:
+        return None
+    tz = ZoneInfo(validate_timezone_name(timezone_name))
+    local = dt.astimezone(tz)
+    out: list[int] = []
+    for field in fields:
+        key = field.casefold()
+        if key == "year":
+            out.append(local.year)
+        elif key == "month":
+            out.append(local.month)
+        elif key == "day":
+            out.append(local.day)
+        elif key == "hour":
+            out.append(local.hour)
+        elif key == "minute":
+            out.append(local.minute)
+        elif key == "second":
+            out.append(local.second)
+        elif key == "microsecond":
+            out.append(local.microsecond)
+        else:
+            raise SchemaValidationError(
+                f"unsupported time_fields component {field!r}; supported: "
+                "year, month, day, hour, minute, second, microsecond"
+            )
+    return out
+
+
+def parse_interval_micros(value: str) -> int:
+    """Parse a small ISO 8601 duration subset into microseconds.
+
+    Supported units: weeks, days, hours, minutes, seconds. Calendar
+    years/months are deliberately rejected because their duration depends
+    on a reference date.
+    """
+    if not isinstance(value, str):
+        raise SchemaValidationError("INTERVAL literal must be a string")
+    m = _INTERVAL_RE.match(value)
+    if m is None:
+        raise SchemaValidationError(
+            f"unsupported INTERVAL {value!r}; supported examples: P1D, PT3H, P2DT6H"
+        )
+    parts = {k: float(v) if v is not None else 0.0 for k, v in m.groupdict().items()}
+    if not any(parts.values()) and value.upper() != "P0D":
+        raise SchemaValidationError(
+            f"unsupported INTERVAL {value!r}; supported examples: P1D, PT3H, P2DT6H"
+        )
+    seconds = (
+        parts["weeks"] * 7 * 86_400
+        + parts["days"] * 86_400
+        + parts["hours"] * 3_600
+        + parts["minutes"] * 60
+        + parts["seconds"]
+    )
+    return int(seconds * 1_000_000)
+
+
+def interval_micros_to_timedelta(value: int) -> timedelta:
+    return timedelta(microseconds=int(value))
+
+
+def _parse_datetime_string(value: str, default_timezone: str | None) -> datetime:
+    text = value.strip()
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        dt = datetime.fromisoformat(text)
+    except ValueError as e:
+        raise SchemaValidationError(
+            f"TIMESTAMPTZ value {value!r} is not a valid ISO 8601 timestamp"
+        ) from e
+    return _ensure_aware(dt, default_timezone)
+
+
+def _ensure_aware(value: datetime, default_timezone: str | None) -> datetime:
+    if value.tzinfo is not None and value.utcoffset() is not None:
+        return value
+    if default_timezone is None:
+        raise SchemaValidationError(
+            "TIMESTAMPTZ value must include a timezone offset or use a configured timezone"
+        )
+    try:
+        tz = ZoneInfo(default_timezone)
+    except ZoneInfoNotFoundError as e:
+        raise SchemaValidationError(
+            f"unknown timezone {default_timezone!r}"
+        ) from e
+    return value.replace(tzinfo=tz)

--- a/milvus_lite/schema/types.py
+++ b/milvus_lite/schema/types.py
@@ -20,6 +20,7 @@ class DataType(Enum):
     VARCHAR = "varchar"
     JSON = "json"
     ARRAY = "array"
+    TIMESTAMPTZ = "timestamptz"
     FLOAT_VECTOR = "float_vector"
     SPARSE_FLOAT_VECTOR = "sparse_float_vector"
 
@@ -71,6 +72,7 @@ class CollectionSchema:
     version: int = 1
     enable_dynamic_field: bool = False
     functions: List[Function] = field(default_factory=list)
+    properties: Dict[str, Any] = field(default_factory=dict)
 
 
 # DataType -> PyArrow type mapping.
@@ -87,6 +89,7 @@ TYPE_MAP: Dict[DataType, Any] = {
     DataType.VARCHAR: pa.string(),
     DataType.JSON: pa.string(),
     DataType.ARRAY: None,  # resolved at runtime from element_type
+    DataType.TIMESTAMPTZ: pa.timestamp("us", tz="UTC"),
     DataType.FLOAT_VECTOR: None,
     DataType.SPARSE_FLOAT_VECTOR: pa.binary(),
 }

--- a/milvus_lite/schema/validation.py
+++ b/milvus_lite/schema/validation.py
@@ -13,9 +13,22 @@ from milvus_lite.schema.types import (
     Function,
     FunctionType,
 )
+from milvus_lite.schema.timestamptz import parse_timestamptz, validate_timezone_name
 
 # Reserved column names — users may not name fields these.
-RESERVED_FIELD_NAMES = frozenset({"_seq", "_partition", "$meta"})
+#
+# `iso`/`interval` mirror Milvus Plan.g4: they are lexer keywords for
+# TIMESTAMPTZ literals, not identifiers.
+RESERVED_FIELD_NAMES = frozenset({
+    "_seq",
+    "_partition",
+    "$meta",
+    "iso",
+    "ISO",
+    "interval",
+    "INTERVAL",
+})
+_CASE_INSENSITIVE_RESERVED_FIELD_NAMES = frozenset({"iso", "interval"})
 
 # pk dtype must be one of these.
 _PK_ALLOWED_DTYPES = frozenset({DataType.VARCHAR, DataType.INT64})
@@ -32,6 +45,7 @@ _DTYPE_PYTHON_CHECK = {
     DataType.DOUBLE: lambda v: isinstance(v, (int, float)) and not isinstance(v, bool),
     DataType.VARCHAR: lambda v: isinstance(v, str),
     DataType.JSON: lambda v: isinstance(v, (dict, list, str, int, float, bool)) or v is None,
+    DataType.TIMESTAMPTZ: lambda v: isinstance(v, int) and not isinstance(v, bool),
 }
 
 
@@ -39,7 +53,10 @@ _DTYPE_PYTHON_CHECK = {
 # Schema validation
 # ---------------------------------------------------------------------------
 
-def validate_schema(schema: CollectionSchema) -> None:
+def validate_schema(
+    schema: CollectionSchema,
+    default_properties: Optional[dict[str, Any]] = None,
+) -> None:
     """Validate a CollectionSchema definition.
 
     Rules:
@@ -49,12 +66,21 @@ def validate_schema(schema: CollectionSchema) -> None:
     - FLOAT_VECTOR field must have dim > 0
     - primary key field must not be nullable
     - field names must be unique
-    - field names must not collide with reserved names (_seq, _partition, $meta)
+    - field names must not collide with reserved names
     - BM25 function: input must be VARCHAR with enable_analyzer,
       output must be SPARSE_FLOAT_VECTOR
     """
     if not schema.fields:
         raise SchemaValidationError("schema has no fields")
+    if not isinstance(schema.properties, dict):
+        raise SchemaValidationError("schema properties must be a dict")
+
+    default_timezone = None
+    if default_properties and "timezone" in default_properties:
+        default_timezone = validate_timezone_name(default_properties["timezone"])
+    if "timezone" in schema.properties:
+        default_timezone = validate_timezone_name(schema.properties["timezone"])
+        schema.properties["timezone"] = default_timezone
 
     seen_names: set[str] = set()
     pk_fields: list[FieldSchema] = []
@@ -65,7 +91,10 @@ def validate_schema(schema: CollectionSchema) -> None:
     for f in schema.fields:
         if not f.name:
             raise SchemaValidationError("field name must not be empty")
-        if f.name in RESERVED_FIELD_NAMES:
+        if (
+            f.name in RESERVED_FIELD_NAMES
+            or f.name.casefold() in _CASE_INSENSITIVE_RESERVED_FIELD_NAMES
+        ):
             raise SchemaValidationError(
                 f"field name {f.name!r} is reserved (one of {sorted(RESERVED_FIELD_NAMES)})"
             )
@@ -90,6 +119,11 @@ def validate_schema(schema: CollectionSchema) -> None:
                 raise SchemaValidationError(
                     f"ARRAY field {f.name!r} requires element_type"
                 )
+        if f.dtype == DataType.TIMESTAMPTZ and f.default_value is not None:
+            f.default_value = parse_timestamptz(
+                f.default_value,
+                default_timezone=default_timezone,
+            )
 
     if len(pk_fields) == 0:
         raise SchemaValidationError("schema has no primary key field")
@@ -262,7 +296,11 @@ def _function_output_field_names(schema: CollectionSchema) -> frozenset[str]:
     return frozenset(names)
 
 
-def validate_record(record: dict, schema: CollectionSchema) -> None:
+def validate_record(
+    record: dict,
+    schema: CollectionSchema,
+    default_properties: Optional[dict[str, Any]] = None,
+) -> None:
     """Validate a single record dict against the schema.
 
     Rules:
@@ -287,6 +325,9 @@ def validate_record(record: dict, schema: CollectionSchema) -> None:
                 record[f.name] = copy.deepcopy(f.default_value)
 
     schema_field_names = {f.name for f in schema.fields}
+    default_timezone = schema.properties.get("timezone")
+    if default_timezone is None and default_properties:
+        default_timezone = default_properties.get("timezone")
     pk = _find_pk(schema)
     func_output_names = _function_output_field_names(schema)
 
@@ -375,6 +416,17 @@ def validate_record(record: dict, schema: CollectionSchema) -> None:
                     f"field {f.name!r} is None but not nullable"
                 )
             continue
+        if f.dtype == DataType.TIMESTAMPTZ:
+            try:
+                record[f.name] = parse_timestamptz(
+                    value,
+                    default_timezone=default_timezone,
+                )
+            except SchemaValidationError as e:
+                raise SchemaValidationError(
+                    f"field {f.name!r} value {value!r} does not match dtype {f.dtype}"
+                ) from e
+            value = record[f.name]
         # VARCHAR max_length check
         if f.dtype == DataType.VARCHAR and f.max_length is not None:
             if isinstance(value, str) and len(value) > f.max_length:

--- a/milvus_lite/search/filter/__init__.py
+++ b/milvus_lite/search/filter/__init__.py
@@ -22,14 +22,22 @@ from milvus_lite.search.filter.semantic import CompiledExpr, FieldInfo, compile_
 from milvus_lite.search.filter.eval import evaluate
 
 
-def compile_filter(source: str, schema) -> CompiledExpr:
+def compile_filter(
+    source: str,
+    schema,
+    default_timezone: str | None = None,
+) -> CompiledExpr:
     """Convenience: parse_expr + compile_expr in one call.
 
     Most call sites that already have the source string and the schema
     use this rather than the two-step API. Two-step is useful when you
     want to cache parsed AST across schemas (Phase F2c).
     """
-    return compile_expr(parse_expr(source), schema, source=source)
+    return compile_expr(
+        parse_expr(source, default_timezone=default_timezone),
+        schema,
+        source=source,
+    )
 
 
 __all__ = [

--- a/milvus_lite/search/filter/ast.py
+++ b/milvus_lite/search/filter/ast.py
@@ -45,8 +45,22 @@ class BoolLit:
     pos: int
 
 
+@dataclass(frozen=True)
+class TimestampLit:
+    """``ISO '2025-01-01T00:00:00Z'`` TIMESTAMPTZ literal."""
+    value: int  # UTC Unix microseconds
+    pos: int
+
+
+@dataclass(frozen=True)
+class IntervalLit:
+    """``INTERVAL 'P1D'`` duration literal, stored as microseconds."""
+    value: int
+    pos: int
+
+
 # Literal alias for use in ListLit (a list contains only simple literals).
-Literal = Union[IntLit, FloatLit, StringLit, BoolLit]
+Literal = Union[IntLit, FloatLit, StringLit, BoolLit, TimestampLit]
 
 
 @dataclass(frozen=True)
@@ -242,7 +256,7 @@ class ArrayAccessOp:
 # ── Type alias for the union of all node types ──────────────────────────────
 
 Expr = Union[
-    IntLit, FloatLit, StringLit, BoolLit,
+    IntLit, FloatLit, StringLit, BoolLit, TimestampLit, IntervalLit,
     ListLit,
     FieldRef,
     CmpOp, InOp, And, Or, Not,

--- a/milvus_lite/search/filter/eval/arrow_backend.py
+++ b/milvus_lite/search/filter/eval/arrow_backend.py
@@ -27,6 +27,7 @@ from milvus_lite.search.filter.ast import (
     FloatLit,
     InOp,
     IntLit,
+    IntervalLit,
     IsNullOp,
     LikeOp,
     ListLit,
@@ -34,7 +35,9 @@ from milvus_lite.search.filter.ast import (
     Not,
     Or,
     StringLit,
+    TimestampLit,
 )
+from milvus_lite.schema.timestamptz import micros_to_utc_datetime
 
 if TYPE_CHECKING:
     from milvus_lite.search.filter.semantic import CompiledExpr
@@ -119,6 +122,13 @@ def _eval(node, table):
         return pa.scalar(node.value, type=pa.string())
     if isinstance(node, BoolLit):
         return pa.scalar(node.value, type=pa.bool_())
+    if isinstance(node, TimestampLit):
+        return pa.scalar(
+            micros_to_utc_datetime(node.value),
+            type=pa.timestamp("us", tz="UTC"),
+        )
+    if isinstance(node, IntervalLit):
+        return pa.scalar(node.value, type=pa.duration("us"))
 
     if isinstance(node, FieldRef):
         col = table.column(node.name)
@@ -140,7 +150,7 @@ def _eval(node, table):
         # comes from the literals; semantic.py has already verified
         # type compatibility with the field, so pyarrow's auto-cast
         # handles any int/float promotion.
-        py_values = [el.value for el in node.values.elements]
+        py_values = [_eval(el, table).as_py() for el in node.values.elements]
         if not py_values:
             # Empty list: `in []` → all False, `not in []` → all True.
             val = node.negate  # False for `in`, True for `not in`

--- a/milvus_lite/search/filter/eval/python_backend.py
+++ b/milvus_lite/search/filter/eval/python_backend.py
@@ -28,6 +28,7 @@ from milvus_lite.search.filter.ast import (
     FloatLit,
     InOp,
     IntLit,
+    IntervalLit,
     IsNullOp,
     LikeOp,
     ListLit,
@@ -35,11 +36,16 @@ from milvus_lite.search.filter.ast import (
     Not,
     Or,
     StringLit,
+    TimestampLit,
     JsonAccess,
     TextMatchOp,
     ArrayContainsOp,
     ArrayLengthOp,
     ArrayAccessOp,
+)
+from milvus_lite.schema.timestamptz import (
+    interval_micros_to_timedelta,
+    micros_to_utc_datetime,
 )
 
 if TYPE_CHECKING:
@@ -129,6 +135,10 @@ def _eval_row(node, row: dict) -> Any:
         return node.value
     if isinstance(node, BoolLit):
         return node.value
+    if isinstance(node, TimestampLit):
+        return micros_to_utc_datetime(node.value)
+    if isinstance(node, IntervalLit):
+        return interval_micros_to_timedelta(node.value)
 
     if isinstance(node, FieldRef):
         return row.get(node.name)
@@ -149,7 +159,7 @@ def _eval_row(node, row: dict) -> Any:
         val = _eval_row(node.field, row)
         if val is None:
             return None  # NULL propagation (Kleene logic)
-        members = {el.value for el in node.values.elements}
+        members = {_eval_row(el, row) for el in node.values.elements}
         result = val in members
         return (not result) if node.negate else result
 

--- a/milvus_lite/search/filter/parser.py
+++ b/milvus_lite/search/filter/parser.py
@@ -35,6 +35,7 @@ from milvus_lite.search.filter.ast import (
     FloatLit,
     InOp,
     IntLit,
+    IntervalLit,
     ArrayAccessOp,
     ArrayContainsOp,
     ArrayLengthOp,
@@ -47,10 +48,12 @@ from milvus_lite.search.filter.ast import (
     Not,
     Or,
     StringLit,
+    TimestampLit,
     TextMatchOp,
 )
 from milvus_lite.search.filter.exceptions import FilterParseError
 from milvus_lite.search.filter.tokens import Token, TokenKind, tokenize
+from milvus_lite.schema.timestamptz import parse_interval_micros, parse_timestamptz
 
 
 _CMP_KINDS = (
@@ -68,9 +71,15 @@ _CMP_TEXT = {
 class Parser:
     """Recursive-descent parser; instances are single-use (one parse call)."""
 
-    def __init__(self, tokens: List[Token], source: str) -> None:
+    def __init__(
+        self,
+        tokens: List[Token],
+        source: str,
+        default_timezone: str | None = None,
+    ) -> None:
         self.tokens = tokens
         self.source = source
+        self.default_timezone = default_timezone
         self.pos = 0
 
     # ── public entry ────────────────────────────────────────────
@@ -458,23 +467,14 @@ class Parser:
 
     def parse_primary(self) -> Expr:
         """prec 6: literal | ident | (expr)."""
+        lit = self._parse_literal()
+        if lit is not None:
+            return lit
+
         tok = self._peek()
 
-        if tok.kind == TokenKind.INT:
-            self._consume()
-            return IntLit(value=tok.value, pos=tok.pos)
-
-        if tok.kind == TokenKind.FLOAT:
-            self._consume()
-            return FloatLit(value=tok.value, pos=tok.pos)
-
-        if tok.kind == TokenKind.STRING:
-            self._consume()
-            return StringLit(value=tok.value, pos=tok.pos)
-
-        if tok.kind == TokenKind.BOOL:
-            self._consume()
-            return BoolLit(value=tok.value, pos=tok.pos)
+        if tok.kind == TokenKind.INTERVAL:
+            return self._parse_interval_literal(tok)
 
         if tok.kind == TokenKind.IDENT:
             self._consume()
@@ -530,6 +530,43 @@ class Parser:
             hint="expected literal, identifier, or '('",
         )
 
+    def _parse_timestamp_literal(self, tok: Token) -> Expr:
+        """Parse ``ISO '...'`` as a TIMESTAMPTZ literal."""
+        iso_tok = self._consume()  # ISO
+        value_tok = self._peek()
+        if value_tok.kind != TokenKind.STRING:
+            raise FilterParseError(
+                "ISO timestamp literal requires a string",
+                self.source, value_tok.pos,
+                hint="example: ISO '2025-01-01T00:00:00Z'",
+            )
+        self._consume()
+        try:
+            value = parse_timestamptz(
+                value_tok.value,
+                default_timezone=self.default_timezone,
+            )
+        except Exception as e:
+            raise FilterParseError(str(e), self.source, value_tok.pos) from e
+        return TimestampLit(value=value, pos=iso_tok.pos)
+
+    def _parse_interval_literal(self, tok: Token) -> Expr:
+        """Parse ``INTERVAL 'P1D'`` as a duration literal."""
+        interval_tok = self._consume()  # INTERVAL
+        value_tok = self._peek()
+        if value_tok.kind != TokenKind.STRING:
+            raise FilterParseError(
+                "INTERVAL literal requires a string",
+                self.source, value_tok.pos,
+                hint="example: INTERVAL 'P1D'",
+            )
+        self._consume()
+        try:
+            value = parse_interval_micros(value_tok.value)
+        except Exception as e:
+            raise FilterParseError(str(e), self.source, value_tok.pos) from e
+        return IntervalLit(value=value, pos=interval_tok.pos)
+
     def parse_list_literal(self) -> ListLit:
         """Parse `[ literal (',' literal)* (',')? ]`. Caller has not
         yet consumed the '['."""
@@ -576,6 +613,18 @@ class Parser:
                 return IntLit(value=-inner.value, pos=sub_tok.pos)
             return FloatLit(value=-inner.value, pos=sub_tok.pos)
 
+        lit = self._parse_literal()
+        if lit is not None:
+            return lit
+
+        raise FilterParseError(
+            f"list elements must be literals, got {tok.text!r}",
+            self.source, tok.pos, span=max(1, len(tok.text)),
+        )
+
+    def _parse_literal(self) -> Optional[Literal]:
+        """Parse scalar literals shared by primary expressions and lists."""
+        tok = self._peek()
         if tok.kind == TokenKind.INT:
             self._consume()
             return IntLit(value=tok.value, pos=tok.pos)
@@ -588,11 +637,9 @@ class Parser:
         if tok.kind == TokenKind.BOOL:
             self._consume()
             return BoolLit(value=tok.value, pos=tok.pos)
-
-        raise FilterParseError(
-            f"list elements must be literals, got {tok.text!r}",
-            self.source, tok.pos, span=max(1, len(tok.text)),
-        )
+        if tok.kind == TokenKind.ISO:
+            return self._parse_timestamp_literal(tok)
+        return None
 
     # ── token utilities ─────────────────────────────────────────
 
@@ -619,11 +666,11 @@ def left_pos_of(node: Expr) -> int:
     return getattr(node, "pos", 0)
 
 
-def parse_expr(source: str) -> Expr:
+def parse_expr(source: str, default_timezone: str | None = None) -> Expr:
     """Public entry point: lex + parse a single expression.
 
     Raises:
         FilterParseError: on lex or parse errors. Always carries source + pos.
     """
     tokens = tokenize(source)
-    return Parser(tokens, source).parse()
+    return Parser(tokens, source, default_timezone=default_timezone).parse()

--- a/milvus_lite/search/filter/semantic.py
+++ b/milvus_lite/search/filter/semantic.py
@@ -27,6 +27,7 @@ from milvus_lite.search.filter.ast import (
     FloatLit,
     InOp,
     IntLit,
+    IntervalLit,
     IsNullOp,
     LikeOp,
     ListLit,
@@ -35,6 +36,7 @@ from milvus_lite.search.filter.ast import (
     Not,
     Or,
     StringLit,
+    TimestampLit,
     JsonAccess,
     TextMatchOp,
     ArrayContainsOp,
@@ -56,12 +58,14 @@ SEM_INT = "int"
 SEM_FLOAT = "float"
 SEM_STRING = "string"
 SEM_BOOL = "bool"
+SEM_TIMESTAMPTZ = "timestamptz"
+SEM_INTERVAL = "interval"
 # Phase F2b: $meta["key"] returns a value whose type is unknown until
 # runtime. SEM_DYNAMIC is compatible with any other type for the purpose
 # of comparisons / IN / arithmetic — runtime semantics decide.
 SEM_DYNAMIC = "dynamic"
 
-_SEM_TYPES = {SEM_INT, SEM_FLOAT, SEM_STRING, SEM_BOOL, SEM_DYNAMIC}
+_SEM_TYPES = {SEM_INT, SEM_FLOAT, SEM_STRING, SEM_BOOL, SEM_TIMESTAMPTZ, SEM_INTERVAL, SEM_DYNAMIC}
 
 # Reserved field names that must not be referenced from filter expressions.
 _RESERVED_FIELDS = frozenset({"_seq", "_partition", "$meta"})
@@ -78,6 +82,8 @@ def _datatype_to_sem(dtype: DataType) -> Optional[str]:
         return SEM_STRING
     if dtype == DataType.BOOL:
         return SEM_BOOL
+    if dtype == DataType.TIMESTAMPTZ:
+        return SEM_TIMESTAMPTZ
     if dtype == DataType.JSON:
         return SEM_STRING  # JSON column is stored as string in Phase F1
     if dtype == DataType.ARRAY:
@@ -93,6 +99,8 @@ def _types_compatible(left: str, right: str) -> bool:
     if left == right:
         return True
     if {left, right} == {SEM_INT, SEM_FLOAT}:
+        return True
+    if left == SEM_TIMESTAMPTZ and right == SEM_TIMESTAMPTZ:
         return True
     if SEM_DYNAMIC in (left, right):
         return True
@@ -300,6 +308,10 @@ def _check_node(node: Expr, ctx: "_CompileCtx") -> str:
         return SEM_STRING
     if isinstance(node, BoolLit):
         return SEM_BOOL
+    if isinstance(node, TimestampLit):
+        return SEM_TIMESTAMPTZ
+    if isinstance(node, IntervalLit):
+        return SEM_INTERVAL
 
     # ── ListLit (only used inside InOp; pure-form is rare) ──────
     if isinstance(node, ListLit):
@@ -397,6 +409,11 @@ def _check_node(node: Expr, ctx: "_CompileCtx") -> str:
     if isinstance(node, ArithOp):
         left_type = _check_node(node.left, ctx)
         right_type = _check_node(node.right, ctx)
+        if node.op in ("+", "-"):
+            if left_type == SEM_TIMESTAMPTZ and right_type == SEM_INTERVAL:
+                return SEM_TIMESTAMPTZ
+            if node.op == "+" and left_type == SEM_INTERVAL and right_type == SEM_TIMESTAMPTZ:
+                return SEM_TIMESTAMPTZ
         # Numeric (int/float) AND dynamic ($meta) are allowed.
         for side, t in (("left", left_type), ("right", right_type)):
             if t not in (SEM_INT, SEM_FLOAT, SEM_DYNAMIC):

--- a/milvus_lite/search/filter/tokens.py
+++ b/milvus_lite/search/filter/tokens.py
@@ -75,6 +75,10 @@ class TokenKind(Enum):
     # Sentinel
     EOF = "EOF"
 
+    # TIMESTAMPTZ literals
+    ISO = "ISO"
+    INTERVAL = "INTERVAL"
+
 
 @dataclass(frozen=True)
 class Token:
@@ -95,6 +99,8 @@ _KEYWORD_MAP = {
     "like": TokenKind.LIKE, "LIKE": TokenKind.LIKE,
     "is": TokenKind.IS, "IS": TokenKind.IS,
     "null": TokenKind.NULL, "NULL": TokenKind.NULL,
+    "iso": TokenKind.ISO, "ISO": TokenKind.ISO,
+    "interval": TokenKind.INTERVAL, "INTERVAL": TokenKind.INTERVAL,
 }
 
 # Boolean literals — only these 6 forms are accepted as bool.

--- a/tests/adapter/test_grpc_timestamptz_milvus_compat.py
+++ b/tests/adapter/test_grpc_timestamptz_milvus_compat.py
@@ -1,0 +1,531 @@
+"""MilvusClient TIMESTAMPTZ compatibility tests.
+
+Migrated and reduced from:
+``~/Workspace/dev/milvus/tests/python_client/milvus_client/test_milvus_client_timestamptz.py``.
+
+MilvusLite currently implements the core TIMESTAMPTZ surface: schema,
+insert/query/search filters, nullable/default values, UTC
+normalization, database/collection/request-level timezone properties,
+and time_fields extraction. Schema evolution and STL_SORT timestamp
+indexes are tracked as follow-up work in the roadmap.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("pymilvus")
+from pymilvus import DataType, MilvusClient  # noqa: E402
+
+
+DIM = 3
+PK = "id"
+VEC = "vector"
+TS = "timestamp"
+_MISSING = object()
+
+
+def _schema(nullable: bool = True, default_value=_MISSING):
+    schema = MilvusClient.create_schema(auto_id=False, enable_dynamic_field=False)
+    schema.add_field(PK, DataType.INT64, is_primary=True)
+    schema.add_field(VEC, DataType.FLOAT_VECTOR, dim=DIM)
+    kwargs = {"nullable": nullable}
+    if default_value is not _MISSING:
+        kwargs["default_value"] = default_value
+    schema.add_field(TS, DataType.TIMESTAMPTZ, **kwargs)
+    return schema
+
+
+def _rows():
+    return [
+        {PK: 0, VEC: [1.0, 2.0, 3.0], TS: "2025-01-01T00:00:00+08:00"},
+        {PK: 1, VEC: [4.0, 5.0, 6.0], TS: "2025-01-03T00:00:00Z"},
+        {PK: 2, VEC: [7.0, 8.0, 9.0], TS: "2024-02-29T00:00:00+03:00"},
+        {PK: 3, VEC: [10.0, 11.0, 12.0], TS: None},
+    ]
+
+
+def _by_id(rows):
+    return {row[PK]: row for row in rows}
+
+
+def _describe_properties(client: MilvusClient, collection: str) -> dict:
+    description = client.describe_collection(collection)
+    return description.get("properties") or {}
+
+
+def test_milvus_client_timestamptz_utc_insert_query(milvus_client):
+    collection = "ts_utc"
+    milvus_client.create_collection(collection, schema=_schema())
+    milvus_client.insert(collection, _rows())
+
+    rows = milvus_client.query(
+        collection,
+        filter=f"{PK} >= 0",
+        output_fields=[PK, TS],
+    )
+
+    got = _by_id(rows)
+    assert got[0][TS] == "2024-12-31T16:00:00Z"
+    assert got[1][TS] == "2025-01-03T00:00:00Z"
+    assert got[2][TS] == "2024-02-28T21:00:00Z"
+    assert got[3][TS] is None
+
+
+def test_milvus_client_timestamptz_query_operators_and_interval(milvus_client):
+    collection = "ts_query"
+    milvus_client.create_collection(collection, schema=_schema())
+    milvus_client.insert(collection, _rows())
+
+    rows = milvus_client.query(
+        collection,
+        filter=f"{TS} >= ISO '2025-01-01T00:00:00Z'",
+        output_fields=[PK, TS],
+    )
+    assert sorted(row[PK] for row in rows) == [1]
+
+    rows = milvus_client.query(
+        collection,
+        filter=f"{TS} <= ISO '2024-12-31T16:00:00Z'",
+        output_fields=[PK, TS],
+    )
+    assert sorted(row[PK] for row in rows) == [0, 2]
+
+    rows = milvus_client.query(
+        collection,
+        filter=f"{TS} != ISO '2025-01-03T00:00:00Z'",
+        output_fields=[PK, TS],
+    )
+    assert sorted(row[PK] for row in rows) == [0, 2]
+
+    rows = milvus_client.query(
+        collection,
+        filter=f"{TS} + INTERVAL 'P1D' <= ISO '2025-01-01T16:00:00Z'",
+        output_fields=[PK, TS],
+    )
+    assert sorted(row[PK] for row in rows) == [0, 2]
+
+    rows = milvus_client.query(
+        collection,
+        filter=f"{TS} is null",
+        output_fields=[PK, TS],
+    )
+    assert rows == [{PK: 3, TS: None}]
+
+
+def test_milvus_client_timestamptz_default_value(milvus_client):
+    collection = "ts_default"
+    milvus_client.create_collection(
+        collection,
+        schema=_schema(default_value="2025-01-01T00:00:00Z"),
+    )
+    milvus_client.insert(collection, [
+        {PK: 0, VEC: [1.0, 2.0, 3.0]},
+        {PK: 1, VEC: [4.0, 5.0, 6.0], TS: None},
+    ])
+
+    rows = milvus_client.query(collection, filter=f"{PK} >= 0", output_fields=[PK, TS])
+    got = _by_id(rows)
+    assert got[0][TS] == "2025-01-01T00:00:00Z"
+    assert got[1][TS] == "2025-01-01T00:00:00Z"
+
+
+def test_milvus_client_timestamptz_default_value_uses_collection_timezone(milvus_client):
+    collection = "ts_default_timezone"
+    milvus_client.create_collection(
+        collection,
+        schema=_schema(default_value="2025-01-01T00:00:00"),
+        properties={"timezone": "Asia/Shanghai"},
+    )
+    milvus_client.insert(collection, [
+        {PK: 0, VEC: [1.0, 2.0, 3.0]},
+        {PK: 1, VEC: [4.0, 5.0, 6.0], TS: None},
+    ])
+
+    rows = milvus_client.query(collection, filter=f"{PK} >= 0", output_fields=[PK, TS])
+    got = _by_id(rows)
+    assert got[0][TS] == "2024-12-31T16:00:00Z"
+    assert got[1][TS] == "2024-12-31T16:00:00Z"
+
+
+def test_milvus_client_timestamptz_search_filter(milvus_client):
+    collection = "ts_search"
+    milvus_client.create_collection(collection, schema=_schema())
+    milvus_client.insert(collection, _rows())
+
+    results = milvus_client.search(
+        collection,
+        data=[[1.0, 2.0, 3.0]],
+        limit=10,
+        filter=f"{TS} <= ISO '2024-12-31T16:00:00Z'",
+        output_fields=[PK, TS],
+    )
+
+    assert len(results) == 1
+    assert sorted(hit["id"] for hit in results[0]) == [0, 2]
+    entities = {hit["id"]: hit["entity"] for hit in results[0]}
+    assert entities[0][TS] == "2024-12-31T16:00:00Z"
+    assert entities[2][TS] == "2024-02-28T21:00:00Z"
+
+
+def test_milvus_client_timestamptz_insert_delete_upsert_flush(milvus_client):
+    collection = "ts_dml"
+    milvus_client.create_collection(collection, schema=_schema())
+    milvus_client.insert(collection, _rows())
+
+    milvus_client.delete(collection, filter=f"{PK} < 2")
+    milvus_client.flush(collection)
+    rows = milvus_client.query(collection, filter=f"{PK} >= 0", output_fields=[PK, TS])
+    assert sorted(row[PK] for row in rows) == [2, 3]
+
+    milvus_client.upsert(collection, [
+        {PK: 0, VEC: [1.0, 1.0, 1.0], TS: "2030-01-01T00:00:00Z"},
+        {PK: 2, VEC: [2.0, 2.0, 2.0], TS: "2030-01-02T00:00:00+08:00"},
+    ])
+    milvus_client.flush(collection)
+
+    rows = milvus_client.query(collection, filter=f"{PK} >= 0", output_fields=[PK, TS])
+    got = _by_id(rows)
+    assert sorted(got) == [0, 2, 3]
+    assert got[0][TS] == "2030-01-01T00:00:00Z"
+    assert got[2][TS] == "2030-01-01T16:00:00Z"
+    assert got[3][TS] is None
+
+
+def test_milvus_client_timestamptz_invalid_time_format(milvus_client):
+    collection = "ts_invalid"
+    milvus_client.create_collection(collection, schema=_schema())
+
+    bad_values = [
+        "invalid_time_format",
+        "2025-04-31T00:00:00Z",
+        "2025-02-29T00:00:00Z",
+        "2025-01-01T00:00:00+24:00",
+    ]
+    for i, value in enumerate(bad_values):
+        with pytest.raises(Exception, match="TIMESTAMPTZ|timestamp|timezone|isoformat|ISO"):
+            milvus_client.insert(collection, [{PK: i, VEC: [1.0, 2.0, 3.0], TS: value}])
+
+
+def test_milvus_client_timestamptz_upstream_edge_cases(milvus_client):
+    collection = "ts_edge_cases"
+    milvus_client.create_collection(collection, schema=_schema(nullable=False))
+    rows = [
+        {PK: 0, VEC: [1.0, 2.0, 3.0], TS: "1970-01-01T00:00:00Z"},
+        {PK: 1, VEC: [4.0, 5.0, 6.0], TS: "9999-12-31T23:59:59Z"},
+        {PK: 2, VEC: [7.0, 8.0, 9.0], TS: "2000-01-01T00:00:00+01:00"},
+    ]
+    milvus_client.insert(collection, rows)
+
+    returned = milvus_client.query(collection, filter=f"{PK} >= 0", output_fields=[PK, TS])
+    got = _by_id(returned)
+    assert got[0][TS] == "1970-01-01T00:00:00Z"
+    assert got[1][TS] == "9999-12-31T23:59:59Z"
+    assert got[2][TS] == "1999-12-31T23:00:00Z"
+
+    rows = milvus_client.query(
+        collection,
+        filter=f"{TS} > ISO '9000-01-01T00:00:00Z'",
+        output_fields=[PK],
+    )
+    assert rows == [{PK: 1}]
+
+
+def test_milvus_client_timestamptz_feb_29(milvus_client):
+    collection = "ts_feb29"
+    milvus_client.create_collection(collection, schema=_schema(nullable=False))
+    milvus_client.insert(
+        collection,
+        [{PK: 10, VEC: [13.0, 14.0, 15.0], TS: "2024-02-29T00:00:00+03:00"}],
+    )
+
+    rows = milvus_client.query(
+        collection,
+        filter=f"{TS} == ISO '2024-02-28T21:00:00Z'",
+        output_fields=[PK, TS],
+    )
+    assert rows == [{PK: 10, TS: "2024-02-28T21:00:00Z"}]
+
+
+def test_milvus_client_timestamptz_request_timezone_filter_matrix(milvus_client):
+    collection = "ts_request_timezone_matrix"
+    milvus_client.create_collection(
+        collection,
+        schema=_schema(nullable=False),
+        properties={"timezone": "Asia/Shanghai"},
+    )
+    milvus_client.insert(collection, [
+        {PK: 0, VEC: [1.0, 2.0, 3.0], TS: "2024-12-31T22:00:00Z"},
+        {PK: 1, VEC: [4.0, 5.0, 6.0], TS: "2025-01-01T06:00:00+08:00"},
+        {PK: 2, VEC: [7.0, 8.0, 9.0], TS: "2024-12-31T17:00:00Z"},
+    ])
+
+    rows = milvus_client.query(
+        collection,
+        filter=f"{TS} == ISO '2024-12-31T22:00:00Z'",
+        output_fields=[PK],
+    )
+    assert sorted(row[PK] for row in rows) == [0, 1]
+
+    rows = milvus_client.query(
+        collection,
+        filter=f"{TS} == ISO '2024-12-31 17:00:00'",
+        output_fields=[PK],
+        timezone="America/New_York",
+    )
+    assert sorted(row[PK] for row in rows) == [0, 1]
+
+    rows = milvus_client.query(
+        collection,
+        filter=f"{TS} == ISO '2025-01-01 06:00:00'",
+        output_fields=[PK],
+        timezone="Asia/Shanghai",
+    )
+    assert sorted(row[PK] for row in rows) == [0, 1]
+
+    rows = milvus_client.query(
+        collection,
+        filter=f"{TS} == ISO '2024-12-31 17:00:00'",
+        output_fields=[PK],
+        timezone="Asia/Shanghai",
+    )
+    assert rows == []
+
+
+def test_milvus_client_timestamptz_collection_timezone_property(milvus_client):
+    collection = "ts_timezone_followup"
+    milvus_client.create_collection(
+        collection,
+        schema=_schema(),
+        properties={"timezone": "Asia/Shanghai"},
+    )
+    assert _describe_properties(milvus_client, collection)["timezone"] == "Asia/Shanghai"
+
+    milvus_client.insert(collection, [{PK: 0, VEC: [1.0, 2.0, 3.0], TS: "2025-01-01T00:00:00"}])
+    rows = milvus_client.query(collection, filter=f"{PK} == 0", output_fields=[PK, TS])
+    assert rows[0][TS] == "2024-12-31T16:00:00Z"
+
+    rows = milvus_client.query(
+        collection,
+        filter=f"{TS} == ISO '2025-01-01T00:00:00'",
+        output_fields=[PK, TS],
+        timezone="UTC",
+    )
+    assert rows == []
+
+    rows = milvus_client.search(
+        collection,
+        data=[[1.0, 2.0, 3.0]],
+        limit=10,
+        filter=f"{TS} == ISO '2025-01-01T00:00:00'",
+        output_fields=[PK, TS],
+        timezone="Asia/Shanghai",
+    )
+    assert [hit["id"] for hit in rows[0]] == [0]
+
+    rows = milvus_client.query(
+        collection,
+        filter=f"{PK} == 0",
+        output_fields=[PK, TS],
+        timezone="Asia/Shanghai",
+        time_fields="year, month, day, hour, minute, second, microsecond",
+    )
+    assert rows == [{PK: 0, TS: [2025, 1, 1, 0, 0, 0, 0]}]
+
+    rows = milvus_client.search(
+        collection,
+        data=[[1.0, 2.0, 3.0]],
+        limit=10,
+        filter=f"{PK} == 0",
+        output_fields=[PK, TS],
+        timezone="UTC",
+        time_fields="year, month, day, hour",
+    )
+    assert rows[0][0]["entity"][TS] == [2024, 12, 31, 16]
+
+
+def test_milvus_client_timestamptz_alter_collection_timezone(milvus_client):
+    collection = "ts_alter_timezone"
+    milvus_client.create_collection(
+        collection,
+        schema=_schema(),
+        properties={"timezone": "UTC"},
+    )
+    milvus_client.insert(collection, [
+        {PK: 0, VEC: [1.0, 2.0, 3.0], TS: "2025-01-01T00:00:00Z"},
+        {PK: 1, VEC: [4.0, 5.0, 6.0], TS: "2024-12-31T16:00:00Z"},
+    ])
+
+    rows = milvus_client.query(
+        collection,
+        filter=f"{TS} == ISO '2025-01-01T00:00:00'",
+        output_fields=[PK],
+    )
+    assert rows == [{PK: 0}]
+
+    milvus_client.alter_collection_properties(
+        collection,
+        properties={"timezone": "Asia/Shanghai"},
+    )
+    assert _describe_properties(milvus_client, collection)["timezone"] == "Asia/Shanghai"
+
+    rows = milvus_client.query(
+        collection,
+        filter=f"{TS} == ISO '2025-01-01T00:00:00'",
+        output_fields=[PK],
+    )
+    assert rows == [{PK: 1}]
+
+
+def test_milvus_client_timestamptz_alter_collection_timezone_after_insert(milvus_client):
+    collection = "ts_alter_timezone_after_insert"
+    milvus_client.create_collection(
+        collection,
+        schema=_schema(nullable=False),
+        properties={"timezone": "UTC"},
+    )
+    milvus_client.insert(collection, [
+        {PK: 0, VEC: [1.0, 2.0, 3.0], TS: "2025-01-01T00:00:00"},
+    ])
+
+    rows = milvus_client.query(
+        collection,
+        filter=f"{TS} == ISO '2025-01-01T00:00:00'",
+        output_fields=[PK],
+    )
+    assert rows == [{PK: 0}]
+
+    milvus_client.alter_collection_properties(
+        collection,
+        properties={"timezone": "America/New_York"},
+    )
+    assert _describe_properties(milvus_client, collection)["timezone"] == "America/New_York"
+
+    rows = milvus_client.query(
+        collection,
+        filter=f"{TS} == ISO '2025-01-01T00:00:00'",
+        output_fields=[PK],
+    )
+    assert rows == []
+
+    milvus_client.insert(collection, [
+        {PK: 1, VEC: [4.0, 5.0, 6.0], TS: "2025-01-01T00:00:00"},
+    ])
+    rows = milvus_client.query(
+        collection,
+        filter=f"{TS} == ISO '2025-01-01T00:00:00'",
+        output_fields=[PK],
+    )
+    assert rows == [{PK: 1}]
+
+
+def test_milvus_client_timestamptz_database_timezone_default(milvus_client):
+    collection = "ts_database_timezone_default"
+    try:
+        milvus_client.alter_database_properties(
+            "default",
+            properties={"timezone": "Asia/Shanghai"},
+        )
+        assert milvus_client.describe_database("default")["timezone"] == "Asia/Shanghai"
+
+        milvus_client.create_collection(collection, schema=_schema(nullable=False))
+        milvus_client.insert(collection, [
+            {PK: 0, VEC: [1.0, 2.0, 3.0], TS: "2025-01-01T00:00:00"},
+        ])
+        rows = milvus_client.query(collection, filter=f"{PK} == 0", output_fields=[PK, TS])
+        assert rows == [{PK: 0, TS: "2024-12-31T16:00:00Z"}]
+
+        milvus_client.alter_database_properties(
+            "default",
+            properties={"timezone": "America/New_York"},
+        )
+        milvus_client.insert(collection, [
+            {PK: 1, VEC: [4.0, 5.0, 6.0], TS: "2025-01-01T00:00:00"},
+        ])
+
+        rows = milvus_client.query(
+            collection,
+            filter=f"{TS} == ISO '2025-01-01T00:00:00'",
+            output_fields=[PK],
+        )
+        assert rows == [{PK: 1}]
+    finally:
+        milvus_client.drop_database_properties("default", ["timezone"])
+
+
+def test_milvus_client_timestamptz_different_time_expressions(milvus_client):
+    collection = "ts_different_time_expressions"
+    milvus_client.create_collection(
+        collection,
+        schema=_schema(nullable=False),
+        properties={"timezone": "Asia/Shanghai"},
+    )
+    milvus_client.insert(collection, [
+        {PK: 40, VEC: [1.0, 2.0, 3.0], TS: "2024-12-31 22:00:00Z"},
+        {PK: 41, VEC: [4.0, 5.0, 6.0], TS: "2024-12-31 22:00:00"},
+        {PK: 42, VEC: [7.0, 8.0, 9.0], TS: "2024-12-31T22:00:00"},
+        {PK: 43, VEC: [10.0, 11.0, 12.0], TS: "2024-12-31T22:00:00+08:00"},
+        {PK: 44, VEC: [13.0, 14.0, 15.0], TS: "2024-12-31T22:00:00-08:00"},
+        {PK: 45, VEC: [16.0, 17.0, 18.0], TS: "2024-12-31T22:00:00Z"},
+        {PK: 46, VEC: [19.0, 20.0, 21.0], TS: "2024-12-31 22:00:00+08:00"},
+        {PK: 47, VEC: [22.0, 23.0, 24.0], TS: "2024-12-31 22:00:00-08:00"},
+    ])
+
+    rows = milvus_client.query(
+        collection,
+        filter=f"{TS} == ISO '2024-12-31 22:00:00'",
+        output_fields=[PK],
+    )
+    assert sorted(row[PK] for row in rows) == [41, 42, 43, 46]
+
+    rows = milvus_client.query(
+        collection,
+        filter=f"{TS} == ISO '2024-12-31T22:00:00Z'",
+        output_fields=[PK],
+    )
+    assert sorted(row[PK] for row in rows) == [40, 45]
+
+    rows = milvus_client.query(
+        collection,
+        filter=f"{TS} == ISO '2024-12-31 22:00:00'",
+        output_fields=[PK],
+        timezone="America/Los_Angeles",
+    )
+    assert sorted(row[PK] for row in rows) == [44, 47]
+
+
+def test_milvus_client_timestamptz_different_timezone_query(milvus_client):
+    collection = "ts_different_timezone_query"
+    milvus_client.create_collection(
+        collection,
+        schema=_schema(nullable=False),
+        properties={"timezone": "UTC"},
+    )
+    milvus_client.insert(collection, [
+        {PK: 50, VEC: [1.0, 2.0, 3.0], TS: "2025-01-01T00:00:00Z"},
+        {PK: 51, VEC: [4.0, 5.0, 6.0], TS: "2024-12-31T16:00:00Z"},
+        {PK: 52, VEC: [7.0, 8.0, 9.0], TS: "2025-01-01T05:00:00Z"},
+    ])
+
+    rows = milvus_client.query(
+        collection,
+        filter=f"{TS} == ISO '2025-01-01T00:00:00'",
+        output_fields=[PK],
+    )
+    assert rows == [{PK: 50}]
+
+    rows = milvus_client.query(
+        collection,
+        filter=f"{TS} == ISO '2025-01-01T00:00:00'",
+        output_fields=[PK],
+        timezone="Asia/Shanghai",
+    )
+    assert rows == [{PK: 51}]
+
+    rows = milvus_client.query(
+        collection,
+        filter=f"{TS} == ISO '2025-01-01T00:00:00'",
+        output_fields=[PK],
+        timezone="America/New_York",
+    )
+    assert rows == [{PK: 52}]

--- a/tests/adapter/test_grpc_translators_records.py
+++ b/tests/adapter/test_grpc_translators_records.py
@@ -24,6 +24,7 @@ from milvus_lite.adapter.grpc.translators.records import (
 )
 from milvus_lite.exceptions import SchemaValidationError
 from milvus_lite.schema.types import CollectionSchema, DataType, FieldSchema
+from milvus_lite.schema.timestamptz import micros_to_iso_z, parse_timestamptz
 
 
 # ---------------------------------------------------------------------------
@@ -99,6 +100,20 @@ def test_decode_json_field():
     assert records[0]["data"] == {"k": 1}
     assert records[1]["data"] == {"k": "two"}
     assert records[2]["data"] == [1, 2, 3]
+
+
+def test_decode_timestamptz_field():
+    ts = parse_timestamptz("2025-01-01T00:00:00Z")
+    fd = _scalar_fd("tsz", 26, "string_data", ["2025-01-01T00:00:00Z"])
+    records = fields_data_to_records([fd], num_rows=1)
+    assert records == [{"tsz": ts}]
+
+
+def test_decode_timestamptz_field_from_native_proto_slot():
+    ts = parse_timestamptz("2025-01-01T00:00:00Z")
+    fd = _scalar_fd("tsz", 26, "timestamptz_data", [ts])
+    records = fields_data_to_records([fd], num_rows=1)
+    assert records == [{"tsz": ts}]
 
 
 def test_decode_empty_request():
@@ -214,6 +229,56 @@ def test_encode_basic_round_trip():
     assert records_out[0]["active"] is True
     assert abs(records_out[0]["score"] - 0.5) < 1e-6
     assert records_out[1]["title"] == "b"
+
+
+def test_encode_timestamptz_round_trip():
+    schema = CollectionSchema(fields=[
+        FieldSchema(name="id", dtype=DataType.INT64, is_primary=True),
+        FieldSchema(name="vec", dtype=DataType.FLOAT_VECTOR, dim=2),
+        FieldSchema(name="tsz", dtype=DataType.TIMESTAMPTZ, nullable=True),
+    ])
+    ts = parse_timestamptz("2025-01-01T00:00:00+08:00")
+    fields_data = records_to_fields_data([
+        {"id": 1, "vec": [0.1, 0.2], "tsz": ts},
+        {"id": 2, "vec": [0.2, 0.3], "tsz": None},
+    ], schema)
+    tsz_fd = next(fd for fd in fields_data if fd.field_name == "tsz")
+    assert tsz_fd.type == 26
+    assert list(tsz_fd.valid_data) == [True, False]
+    assert list(tsz_fd.scalars.string_data.data) == [micros_to_iso_z(ts), ""]
+
+    records = fields_data_to_records(fields_data, num_rows=2)
+    assert records[0]["tsz"] == ts
+    assert records[1]["tsz"] is None
+
+
+def test_encode_timestamptz_time_fields():
+    schema = CollectionSchema(fields=[
+        FieldSchema(name="id", dtype=DataType.INT64, is_primary=True),
+        FieldSchema(name="vec", dtype=DataType.FLOAT_VECTOR, dim=2),
+        FieldSchema(name="tsz", dtype=DataType.TIMESTAMPTZ, nullable=True),
+    ])
+    ts = parse_timestamptz("2024-12-31T16:00:01.123456Z")
+
+    fields_data = records_to_fields_data(
+        [
+            {"id": 1, "vec": [0.1, 0.2], "tsz": ts},
+            {"id": 2, "vec": [0.2, 0.3], "tsz": None},
+        ],
+        schema,
+        output_fields=["tsz"],
+        time_fields="year, month, day, hour, minute, second, microsecond",
+        timezone="Asia/Shanghai",
+    )
+
+    tsz_fd = next(fd for fd in fields_data if fd.field_name == "tsz")
+    assert tsz_fd.type == 22
+    assert tsz_fd.scalars.array_data.element_type == 5
+    assert list(tsz_fd.valid_data) == [True, False]
+    assert list(tsz_fd.scalars.array_data.data[0].long_data.data) == [
+        2025, 1, 1, 0, 0, 1, 123456,
+    ]
+    assert list(tsz_fd.scalars.array_data.data[1].long_data.data) == []
 
 
 def test_encode_output_fields_subset():

--- a/tests/adapter/test_grpc_translators_schema.py
+++ b/tests/adapter/test_grpc_translators_schema.py
@@ -35,6 +35,7 @@ def test_round_trip_all_supported_types():
         FieldSchema(name="i16", dtype=DataType.INT16),
         FieldSchema(name="i32", dtype=DataType.INT32),
         FieldSchema(name="data", dtype=DataType.JSON),
+        FieldSchema(name="tsz", dtype=DataType.TIMESTAMPTZ, nullable=True),
     ])
     proto = milvus_lite_to_milvus_schema("test", schema)
     decoded = milvus_to_milvus_lite_schema(proto)
@@ -50,6 +51,7 @@ def test_round_trip_all_supported_types():
     assert by_name["vec"].dim == 128
     # varchar max_length preserved
     assert by_name["title"].max_length == 512
+    assert by_name["tsz"].nullable is True
 
 
 def test_round_trip_dynamic_field_flag():
@@ -215,6 +217,22 @@ def test_round_trip_default_value_int64():
     decoded = milvus_to_milvus_lite_schema(proto)
     by_name = {f.name: f for f in decoded.fields}
     assert by_name["count"].default_value == 0
+
+
+def test_round_trip_default_value_timestamptz():
+    schema = CollectionSchema(fields=[
+        FieldSchema(name="id", dtype=DataType.INT64, is_primary=True),
+        FieldSchema(name="vec", dtype=DataType.FLOAT_VECTOR, dim=4),
+        FieldSchema(
+            name="created_at",
+            dtype=DataType.TIMESTAMPTZ,
+            default_value="2025-01-01T00:00:00Z",
+        ),
+    ])
+    proto = milvus_lite_to_milvus_schema("dv", schema)
+    decoded = milvus_to_milvus_lite_schema(proto)
+    by_name = {f.name: f for f in decoded.fields}
+    assert by_name["created_at"].default_value > 0
 
 
 def test_round_trip_default_value_bool():

--- a/tests/adapter/test_hybrid_search.py
+++ b/tests/adapter/test_hybrid_search.py
@@ -573,6 +573,53 @@ def test_hybrid_with_filter(milvus_client):
     milvus_client.drop_collection(name)
 
 
+def test_hybrid_timestamptz_timezone_and_time_fields(milvus_client):
+    schema = MilvusClient.create_schema(auto_id=False)
+    schema.add_field("id", DataType.INT64, is_primary=True)
+    schema.add_field("dense", DataType.FLOAT_VECTOR, dim=2)
+    schema.add_field("ts", DataType.TIMESTAMPTZ, nullable=False)
+
+    name = "hybrid_timestamptz"
+    milvus_client.create_collection(
+        name,
+        schema=schema,
+        properties={"timezone": "UTC"},
+    )
+    milvus_client.insert(name, [
+        {"id": 1, "dense": [1.0, 0.0], "ts": "2025-01-01T00:00:00Z"},
+        {"id": 2, "dense": [0.9, 0.0], "ts": "2024-12-31T16:00:00Z"},
+    ])
+
+    idx = milvus_client.prepare_index_params()
+    idx.add_index(field_name="dense", index_type="BRUTE_FORCE",
+                  metric_type="COSINE", params={})
+    milvus_client.create_index(name, idx)
+    milvus_client.load_collection(name)
+
+    req = AnnSearchRequest(
+        data=[[1.0, 0.0]],
+        anns_field="dense",
+        param={},
+        limit=2,
+        expr="ts == ISO '2025-01-01T00:00:00'",
+    )
+
+    results = milvus_client.hybrid_search(
+        name,
+        reqs=[req],
+        ranker=RRFRanker(),
+        limit=2,
+        output_fields=["ts"],
+        timezone="Asia/Shanghai",
+        time_fields="year, month, day, hour",
+    )
+
+    assert [hit["id"] for hit in results[0]] == [2]
+    assert results[0][0]["entity"]["ts"] == [2025, 1, 1, 0]
+
+    milvus_client.drop_collection(name)
+
+
 def test_hybrid_single_route_same_as_search(milvus_client):
     """Hybrid with one route should produce same results as plain search."""
     name = _create_hybrid_collection(milvus_client, "hybrid_single")

--- a/tests/engine/test_collection_filter.py
+++ b/tests/engine/test_collection_filter.py
@@ -787,9 +787,9 @@ def test_filter_cache_lru_eviction(col):
     col._compile_filter("age > 2")
     col._compile_filter("age > 3")  # evicts age > 1
     assert len(col._filter_cache) == 2
-    assert "age > 1" not in col._filter_cache
-    assert "age > 2" in col._filter_cache
-    assert "age > 3" in col._filter_cache
+    assert ("age > 1", None) not in col._filter_cache
+    assert ("age > 2", None) in col._filter_cache
+    assert ("age > 3", None) in col._filter_cache
 
 
 def test_filter_cache_does_not_cache_errors(col):

--- a/tests/engine/test_timestamptz.py
+++ b/tests/engine/test_timestamptz.py
@@ -1,0 +1,258 @@
+"""TIMESTAMPTZ collection-level behavior."""
+
+from datetime import datetime, timezone
+
+from milvus_lite.db import MilvusLite
+from milvus_lite.engine.collection import Collection
+from milvus_lite.schema.timestamptz import micros_to_utc_datetime
+from milvus_lite.schema.types import CollectionSchema, DataType, FieldSchema
+
+
+def _schema() -> CollectionSchema:
+    return CollectionSchema(fields=[
+        FieldSchema(name="id", dtype=DataType.INT64, is_primary=True),
+        FieldSchema(name="vec", dtype=DataType.FLOAT_VECTOR, dim=2),
+        FieldSchema(name="tsz", dtype=DataType.TIMESTAMPTZ, nullable=True),
+    ])
+
+
+def test_timestamptz_query_and_restart(tmp_path):
+    data_dir = str(tmp_path / "data")
+    col = Collection("events", data_dir, _schema())
+    col.insert([
+        {"id": 1, "vec": [0.1, 0.2], "tsz": "2025-01-01T00:00:00+08:00"},
+        {"id": 2, "vec": [0.2, 0.3], "tsz": "2025-01-03T00:00:00Z"},
+        {"id": 3, "vec": [0.3, 0.4], "tsz": None},
+    ])
+
+    rows = col.query(
+        "tsz > ISO '2025-01-02T00:00:00Z'",
+        output_fields=["id", "tsz"],
+    )
+    assert [r["id"] for r in rows] == [2]
+    assert rows[0]["tsz"] == datetime(2025, 1, 3, tzinfo=timezone.utc)
+
+    rows = col.query(
+        "tsz + INTERVAL 'P1D' <= ISO '2025-01-02T16:00:00Z'",
+        output_fields=["id"],
+    )
+    assert [r["id"] for r in rows] == [1]
+    col.close()
+
+    reopened = Collection("events", data_dir, _schema())
+    got = reopened.get([1], output_fields=["id", "tsz"])
+    assert got[0]["tsz"] == micros_to_utc_datetime("2025-01-01T00:00:00+08:00")
+    reopened.close()
+
+
+def test_timestamptz_collection_timezone_persists_and_parses_naive_values(tmp_path):
+    db = MilvusLite(str(tmp_path / "db"))
+    col = db.create_collection(
+        "events",
+        _schema(),
+        properties={"timezone": "Asia/Shanghai"},
+    )
+    col.insert([
+        {"id": 1, "vec": [0.1, 0.2], "tsz": "2025-01-01T00:00:00"},
+        {"id": 2, "vec": [0.2, 0.3], "tsz": "2025-01-02T00:00:00"},
+    ])
+    db.close()
+
+    reopened_db = MilvusLite(str(tmp_path / "db"))
+    reopened = reopened_db.get_collection("events")
+    assert reopened.schema.properties["timezone"] == "Asia/Shanghai"
+
+    rows = reopened.query(
+        "tsz == ISO '2025-01-01T00:00:00'",
+        output_fields=["id", "tsz"],
+    )
+
+    assert [r["id"] for r in rows] == [1]
+    assert rows[0]["tsz"] == datetime(2024, 12, 31, 16, tzinfo=timezone.utc)
+    reopened_db.close()
+
+
+def test_timestamptz_request_timezone_overrides_collection_timezone(tmp_path):
+    col = Collection(
+        "events",
+        str(tmp_path / "data"),
+        CollectionSchema(
+            fields=_schema().fields,
+            properties={"timezone": "UTC"},
+        ),
+    )
+    col.insert([
+        {"id": 1, "vec": [1.0, 0.0], "tsz": "2025-01-01T00:00:00Z"},
+        {"id": 2, "vec": [0.0, 1.0], "tsz": "2024-12-31T16:00:00Z"},
+    ])
+
+    rows = col.query(
+        "tsz == ISO '2025-01-01T00:00:00'",
+        output_fields=["id"],
+    )
+    assert [r["id"] for r in rows] == [1]
+
+    rows = col.query(
+        "tsz == ISO '2025-01-01T00:00:00'",
+        output_fields=["id"],
+        timezone="Asia/Shanghai",
+    )
+    assert [r["id"] for r in rows] == [2]
+    col.close()
+
+
+def test_timestamptz_search_uses_request_timezone(tmp_path):
+    col = Collection(
+        "events",
+        str(tmp_path / "search"),
+        CollectionSchema(fields=_schema().fields),
+    )
+    col.insert([
+        {"id": 1, "vec": [1.0, 0.0], "tsz": "2025-01-01T00:00:00Z"},
+        {"id": 2, "vec": [0.0, 1.0], "tsz": "2024-12-31T16:00:00Z"},
+    ])
+
+    results = col.search(
+        [[1.0, 0.0]],
+        top_k=10,
+        expr="tsz == ISO '2025-01-01T00:00:00'",
+        output_fields=["id"],
+        timezone="Asia/Shanghai",
+    )
+
+    assert [hit["id"] for hit in results[0]] == [2]
+    col.close()
+
+
+def test_timestamptz_alter_collection_timezone_persists(tmp_path):
+    data_dir = str(tmp_path / "db_alter")
+    db = MilvusLite(data_dir)
+    col = db.create_collection(
+        "events",
+        _schema(),
+        properties={"timezone": "UTC"},
+    )
+    col.insert([
+        {"id": 1, "vec": [1.0, 0.0], "tsz": "2025-01-01T00:00:00Z"},
+        {"id": 2, "vec": [0.0, 1.0], "tsz": "2024-12-31T16:00:00Z"},
+    ])
+
+    rows = col.query(
+        "tsz == ISO '2025-01-01T00:00:00'",
+        output_fields=["id"],
+    )
+    assert [r["id"] for r in rows] == [1]
+
+    db.alter_collection_properties(
+        "events",
+        properties={"timezone": "Asia/Shanghai"},
+    )
+    rows = col.query(
+        "tsz == ISO '2025-01-01T00:00:00'",
+        output_fields=["id"],
+    )
+    assert [r["id"] for r in rows] == [2]
+    db.close()
+
+    reopened_db = MilvusLite(data_dir)
+    reopened = reopened_db.get_collection("events")
+    assert reopened.schema.properties["timezone"] == "Asia/Shanghai"
+    rows = reopened.query(
+        "tsz == ISO '2025-01-01T00:00:00'",
+        output_fields=["id"],
+    )
+    assert [r["id"] for r in rows] == [2]
+    reopened_db.close()
+
+
+def test_timestamptz_database_timezone_default_persists_and_affects_existing_collections(tmp_path):
+    data_dir = str(tmp_path / "db_timezone")
+    db = MilvusLite(data_dir)
+    db.alter_database_properties(properties={"timezone": "Asia/Shanghai"})
+    assert db.describe_database()["properties"]["timezone"] == "Asia/Shanghai"
+
+    col = db.create_collection("events", _schema())
+    assert "timezone" not in col.schema.properties
+    col.insert([
+        {"id": 1, "vec": [1.0, 0.0], "tsz": "2025-01-01T00:00:00"},
+    ])
+
+    rows = col.query(
+        "tsz == ISO '2025-01-01T00:00:00'",
+        output_fields=["id", "tsz"],
+    )
+    assert rows == [
+        {"id": 1, "tsz": datetime(2024, 12, 31, 16, tzinfo=timezone.utc)}
+    ]
+
+    db.alter_database_properties(properties={"timezone": "America/New_York"})
+    col.insert([
+        {"id": 2, "vec": [0.0, 1.0], "tsz": "2025-01-01T00:00:00"},
+    ])
+
+    rows = col.query(
+        "tsz == ISO '2025-01-01T00:00:00'",
+        output_fields=["id"],
+    )
+    assert rows == [{"id": 2}]
+    db.close()
+
+    reopened_db = MilvusLite(data_dir)
+    try:
+        assert reopened_db.describe_database()["properties"]["timezone"] == "America/New_York"
+        reopened = reopened_db.get_collection("events")
+        rows = reopened.query(
+            "tsz == ISO '2025-01-01T00:00:00'",
+            output_fields=["id"],
+        )
+        assert rows == [{"id": 2}]
+    finally:
+        reopened_db.close()
+
+
+def test_timestamptz_collection_timezone_overrides_database_timezone(tmp_path):
+    db = MilvusLite(str(tmp_path / "db_timezone_override"))
+    db.alter_database_properties(properties={"timezone": "Asia/Shanghai"})
+    col = db.create_collection(
+        "events",
+        _schema(),
+        properties={"timezone": "UTC"},
+    )
+    col.insert([
+        {"id": 1, "vec": [1.0, 0.0], "tsz": "2025-01-01T00:00:00"},
+        {"id": 2, "vec": [0.0, 1.0], "tsz": "2024-12-31T16:00:00Z"},
+    ])
+
+    rows = col.query(
+        "tsz == ISO '2025-01-01T00:00:00'",
+        output_fields=["id"],
+    )
+    assert rows == [{"id": 1}]
+    db.close()
+
+
+def test_timestamptz_database_timezone_normalizes_default_value(tmp_path):
+    schema = CollectionSchema(
+        fields=[
+            FieldSchema(name="id", dtype=DataType.INT64, is_primary=True),
+            FieldSchema(name="vec", dtype=DataType.FLOAT_VECTOR, dim=2),
+            FieldSchema(
+                name="tsz",
+                dtype=DataType.TIMESTAMPTZ,
+                default_value="2025-01-01T00:00:00",
+            ),
+        ],
+    )
+    db = MilvusLite(str(tmp_path / "db_default_timezone"))
+    db.alter_database_properties(properties={"timezone": "Asia/Shanghai"})
+    col = db.create_collection("events", schema)
+
+    col.insert([
+        {"id": 1, "vec": [1.0, 0.0]},
+    ])
+    rows = col.query("id == 1", output_fields=["id", "tsz"])
+
+    assert rows == [
+        {"id": 1, "tsz": datetime(2024, 12, 31, 16, tzinfo=timezone.utc)}
+    ]
+    db.close()

--- a/tests/schema/test_persistence.py
+++ b/tests/schema/test_persistence.py
@@ -32,6 +32,7 @@ def _full_schema() -> CollectionSchema:
         ],
         version=3,
         enable_dynamic_field=True,
+        properties={"timezone": "Asia/Shanghai"},
     )
 
 
@@ -48,6 +49,7 @@ def test_save_load_roundtrip(tmp_path):
     assert name == "my_collection"
     assert loaded.version == schema.version
     assert loaded.enable_dynamic_field == schema.enable_dynamic_field
+    assert loaded.properties == schema.properties
     assert len(loaded.fields) == len(schema.fields)
     for src, dst in zip(schema.fields, loaded.fields):
         assert src.name == dst.name

--- a/tests/schema/test_types.py
+++ b/tests/schema/test_types.py
@@ -20,13 +20,14 @@ def test_datatype_values():
     assert DataType.FLOAT_VECTOR.value == "float_vector"
     assert DataType.VARCHAR.value == "varchar"
     assert DataType.JSON.value == "json"
+    assert DataType.TIMESTAMPTZ.value == "timestamptz"
 
 
 def test_datatype_members():
     expected = {
         "BOOL", "INT8", "INT16", "INT32", "INT64",
         "FLOAT", "DOUBLE", "VARCHAR", "JSON", "ARRAY",
-        "FLOAT_VECTOR", "SPARSE_FLOAT_VECTOR",
+        "TIMESTAMPTZ", "FLOAT_VECTOR", "SPARSE_FLOAT_VECTOR",
     }
     assert set(DataType.__members__.keys()) == expected
 
@@ -99,6 +100,7 @@ def test_type_map_scalar_types():
     assert TYPE_MAP[DataType.DOUBLE] == pa.float64()
     assert TYPE_MAP[DataType.VARCHAR] == pa.string()
     assert TYPE_MAP[DataType.JSON] == pa.string()
+    assert TYPE_MAP[DataType.TIMESTAMPTZ] == pa.timestamp("us", tz="UTC")
 
 
 def test_type_map_vector_is_none():

--- a/tests/schema/test_validation.py
+++ b/tests/schema/test_validation.py
@@ -1,6 +1,7 @@
 """Tests for schema/validation.py"""
 
 import json
+from datetime import datetime, timezone
 
 import pytest
 
@@ -18,6 +19,7 @@ from milvus_lite.schema.validation import (
     validate_record,
     validate_schema,
 )
+from milvus_lite.schema.timestamptz import parse_timestamptz
 
 
 # ---------------------------------------------------------------------------
@@ -81,6 +83,16 @@ def test_empty_field_name():
 
 @pytest.mark.parametrize("reserved", sorted(RESERVED_FIELD_NAMES))
 def test_reserved_field_name(reserved):
+    with pytest.raises(SchemaValidationError, match="reserved"):
+        validate_schema(CollectionSchema(fields=[
+            FieldSchema(name="id", dtype=DataType.VARCHAR, is_primary=True),
+            FieldSchema(name=reserved, dtype=DataType.VARCHAR),
+            FieldSchema(name="vec", dtype=DataType.FLOAT_VECTOR, dim=4),
+        ]))
+
+
+@pytest.mark.parametrize("reserved", ["Iso", "iSo", "Interval", "inTERVAL"])
+def test_reserved_field_name_is_case_insensitive(reserved):
     with pytest.raises(SchemaValidationError, match="reserved"):
         validate_schema(CollectionSchema(fields=[
             FieldSchema(name="id", dtype=DataType.VARCHAR, is_primary=True),
@@ -172,6 +184,102 @@ def test_valid_record_ok():
     schema = _basic_schema()
     rec = {"id": "doc1", "vec": [0.1, 0.2, 0.3, 0.4], "title": "hi", "score": 0.5}
     validate_record(rec, schema)
+
+
+def test_timestamptz_record_normalized_to_utc_micros():
+    schema = CollectionSchema(fields=[
+        FieldSchema(name="id", dtype=DataType.INT64, is_primary=True),
+        FieldSchema(name="vec", dtype=DataType.FLOAT_VECTOR, dim=2),
+        FieldSchema(name="tsz", dtype=DataType.TIMESTAMPTZ),
+    ])
+    rec = {
+        "id": 1,
+        "vec": [0.1, 0.2],
+        "tsz": "2025-01-01T00:00:00+08:00",
+    }
+
+    validate_record(rec, schema)
+
+    assert rec["tsz"] == parse_timestamptz("2024-12-31T16:00:00Z")
+
+
+def test_timestamptz_accepts_aware_datetime():
+    schema = CollectionSchema(fields=[
+        FieldSchema(name="id", dtype=DataType.INT64, is_primary=True),
+        FieldSchema(name="vec", dtype=DataType.FLOAT_VECTOR, dim=2),
+        FieldSchema(name="tsz", dtype=DataType.TIMESTAMPTZ),
+    ])
+    rec = {
+        "id": 1,
+        "vec": [0.1, 0.2],
+        "tsz": datetime(2025, 1, 1, tzinfo=timezone.utc),
+    }
+
+    validate_record(rec, schema)
+
+    assert rec["tsz"] == parse_timestamptz("2025-01-01T00:00:00Z")
+
+
+def test_timestamptz_rejects_naive_string():
+    schema = CollectionSchema(fields=[
+        FieldSchema(name="id", dtype=DataType.INT64, is_primary=True),
+        FieldSchema(name="vec", dtype=DataType.FLOAT_VECTOR, dim=2),
+        FieldSchema(name="tsz", dtype=DataType.TIMESTAMPTZ),
+    ])
+
+    with pytest.raises(SchemaValidationError, match="TIMESTAMPTZ"):
+        validate_record({
+            "id": 1,
+            "vec": [0.1, 0.2],
+            "tsz": "2025-01-01T00:00:00",
+        }, schema)
+
+
+def test_timestamptz_uses_collection_timezone_for_naive_string():
+    schema = CollectionSchema(
+        fields=[
+            FieldSchema(name="id", dtype=DataType.INT64, is_primary=True),
+            FieldSchema(name="vec", dtype=DataType.FLOAT_VECTOR, dim=2),
+            FieldSchema(name="tsz", dtype=DataType.TIMESTAMPTZ),
+        ],
+        properties={"timezone": "Asia/Shanghai"},
+    )
+    validate_schema(schema)
+    rec = {
+        "id": 1,
+        "vec": [0.1, 0.2],
+        "tsz": "2025-01-01T00:00:00",
+    }
+
+    validate_record(rec, schema)
+
+    assert rec["tsz"] == parse_timestamptz("2024-12-31T16:00:00Z")
+
+
+def test_timestamptz_default_uses_collection_timezone():
+    schema = CollectionSchema(
+        fields=[
+            FieldSchema(name="id", dtype=DataType.INT64, is_primary=True),
+            FieldSchema(name="vec", dtype=DataType.FLOAT_VECTOR, dim=2),
+            FieldSchema(
+                name="tsz",
+                dtype=DataType.TIMESTAMPTZ,
+                default_value="2025-01-01T00:00:00",
+            ),
+        ],
+        properties={"timezone": "Asia/Shanghai"},
+    )
+
+    validate_schema(schema)
+
+    assert schema.fields[2].default_value == parse_timestamptz("2024-12-31T16:00:00Z")
+
+
+def test_schema_rejects_unknown_timezone():
+    schema = _basic_schema(properties={"timezone": "No/Such_Zone"})
+
+    with pytest.raises(SchemaValidationError, match="unknown timezone"):
+        validate_schema(schema)
 
 
 def test_record_not_dict():

--- a/tests/search/filter/test_e2e.py
+++ b/tests/search/filter/test_e2e.py
@@ -9,6 +9,7 @@ that introduces python_backend dispatch will preserve semantics.
 """
 
 from dataclasses import replace
+from datetime import datetime, timezone
 
 import pyarrow as pa
 import pytest
@@ -30,6 +31,7 @@ def schema():
         FieldSchema(name="score", dtype=DataType.FLOAT),
         FieldSchema(name="active", dtype=DataType.BOOL),
         FieldSchema(name="category", dtype=DataType.VARCHAR),
+        FieldSchema(name="tsz", dtype=DataType.TIMESTAMPTZ, nullable=True),
     ])
 
 
@@ -43,6 +45,16 @@ def sample_table():
         "score": [0.1, 0.5, 0.7, 0.3, 0.9, 0.5, 1.0, 0.0],
         "active": [True, False, True, True, False, True, True, False],
         "category": ["news", "tech", "tech", "blog", "news", "tech", "ai", "blog"],
+        "tsz": pa.array([
+            datetime(2024, 12, 31, 16, tzinfo=timezone.utc),
+            datetime(2025, 1, 1, 16, tzinfo=timezone.utc),
+            datetime(2025, 1, 2, 16, tzinfo=timezone.utc),
+            None,
+            datetime(2025, 1, 4, 16, tzinfo=timezone.utc),
+            datetime(2025, 1, 5, 16, tzinfo=timezone.utc),
+            datetime(2025, 1, 6, 16, tzinfo=timezone.utc),
+            datetime(2025, 1, 7, 16, tzinfo=timezone.utc),
+        ], type=pa.timestamp("us", tz="UTC")),
     })
 
 
@@ -157,6 +169,12 @@ DIFFERENTIAL_EXPRESSIONS = [
     "age + 1 > 20 and title like '%i%'",
     "title is not null and age * 2 > 30",
     "(age - 10) * 2 < 50 or score / 2 > 0.4",
+    # ── TIMESTAMPTZ ─────────────────────────────────────────────
+    "tsz > ISO '2025-01-03T00:00:00+08:00'",
+    "tsz + INTERVAL 'P1D' <= ISO '2025-01-06T00:00:00Z'",
+    "tsz - INTERVAL 'PT6H' < ISO '2025-01-05T00:00:00Z'",
+    "tsz in [ISO '2025-01-01T16:00:00Z', ISO '2025-01-05T16:00:00Z']",
+    "tsz is null",
 ]
 
 

--- a/tests/search/filter/test_parser.py
+++ b/tests/search/filter/test_parser.py
@@ -11,6 +11,7 @@ from milvus_lite.search.filter.ast import (
     FloatLit,
     InOp,
     IntLit,
+    IntervalLit,
     IsNullOp,
     LikeOp,
     ListLit,
@@ -18,6 +19,7 @@ from milvus_lite.search.filter.ast import (
     Not,
     Or,
     StringLit,
+    TimestampLit,
 )
 from milvus_lite.search.filter.exceptions import FilterParseError
 from milvus_lite.search.filter.parser import parse_expr
@@ -62,6 +64,28 @@ def test_bool_literal_true():
     e = parse_expr("true")
     assert isinstance(e, BoolLit)
     assert e.value is True
+
+
+def test_timestamp_literal():
+    e = parse_expr("ISO '2025-01-01T00:00:00Z'")
+    assert isinstance(e, TimestampLit)
+    assert e.value > 0
+
+
+def test_timestamp_literal_uses_default_timezone():
+    e = parse_expr(
+        "ISO '2025-01-01T00:00:00'",
+        default_timezone="Asia/Shanghai",
+    )
+    expected = parse_expr("ISO '2024-12-31T16:00:00Z'")
+    assert isinstance(e, TimestampLit)
+    assert e.value == expected.value
+
+
+def test_interval_literal():
+    e = parse_expr("INTERVAL 'P2DT6H'")
+    assert isinstance(e, IntervalLit)
+    assert e.value == (2 * 24 + 6) * 3600 * 1_000_000
 
 
 # ---------------------------------------------------------------------------
@@ -242,6 +266,13 @@ def test_in_trailing_comma():
 def test_in_negative_literal():
     e = parse_expr("temp in [-5, 0, 10]")
     assert [el.value for el in e.values.elements] == [-5, 0, 10]
+
+
+def test_in_timestamp_literal():
+    e = parse_expr("tsz in [ISO '2025-01-01T00:00:00Z']")
+    assert isinstance(e, InOp)
+    assert isinstance(e.values.elements[0], TimestampLit)
+    assert e.values.elements[0].value > 0
 
 
 def test_in_lhs_must_be_field():

--- a/tests/search/filter/test_semantic.py
+++ b/tests/search/filter/test_semantic.py
@@ -19,6 +19,7 @@ def schema():
         FieldSchema(name="score", dtype=DataType.FLOAT),
         FieldSchema(name="active", dtype=DataType.BOOL),
         FieldSchema(name="category", dtype=DataType.VARCHAR),
+        FieldSchema(name="tsz", dtype=DataType.TIMESTAMPTZ, nullable=True),
     ])
 
 
@@ -66,6 +67,11 @@ def test_in_expression(schema):
 
 def test_in_string(schema):
     c = compile_str("category in ['tech', 'news']", schema)
+
+
+def test_in_timestamptz(schema):
+    c = compile_str("tsz in [ISO '2025-01-01T00:00:00Z']", schema)
+    assert "tsz" in c.fields
 
 
 def test_in_empty_list(schema):


### PR DESCRIPTION
Add TIMESTAMPTZ normalization, gRPC translation, ISO/INTERVAL filter literals, and coverage across schema, engine, adapter, and
  search filter paths.