### PR TITLE
feat(schema): add GEOMETRY support

### DIFF
--- a/milvus_lite/adapter/grpc/translators/records.py
+++ b/milvus_lite/adapter/grpc/translators/records.py
@@ -59,10 +59,10 @@ _SCALAR_TYPE_TO_SLOT: Dict[int, str] = {
     5:  "long_data",     # Int64
     10: "float_data",    # Float
     11: "double_data",   # Double
-    21: "string_data",   # VarChar
-    23: "json_data",     # JSON
-    24: "string_data",   # Geometry WKT
-    26: "string_data",   # Timestamptz. pymilvus sends/parses it as string_data.
+    21: "string_data",        # VarChar
+    23: "json_data",          # JSON
+    24: "geometry_wkt_data",  # Geometry WKT
+    26: "string_data",        # Timestamptz. pymilvus sends/parses it as string_data.
 }
 
 _VECTOR_TYPES = frozenset({100, 101, 102, 103, 104, 105})  # Binary/Float/F16/BF16/Sparse/Int8
@@ -228,6 +228,13 @@ def _extract_scalar_column(fd, dtype_int: int) -> List[Any]:
     # Array type (22) — special handling via array_data slot
     if dtype_int == 22:
         return _extract_array_column(fd)
+
+    if dtype_int == 24:
+        if scalars.HasField("geometry_wkt_data"):
+            return list(scalars.geometry_wkt_data.data)
+        if scalars.HasField("string_data"):
+            return list(scalars.string_data.data)
+        return []
 
     if dtype_int == 26:
         if scalars.HasField("timestamptz_data"):

--- a/milvus_lite/adapter/grpc/translators/records.py
+++ b/milvus_lite/adapter/grpc/translators/records.py
@@ -8,11 +8,11 @@ without losing any field, type, or null information.
 
 Phase 10.3 supported types (matches translators/schema.py):
     Bool / Int8 / Int16 / Int32 / Int64 / Float / Double / VarChar
-    JSON / Timestamptz / FloatVector
+    JSON / Geometry / Timestamptz / FloatVector
 
 Unsupported (raise UnsupportedFieldTypeError):
     BinaryVector / Float16Vector / BFloat16Vector / SparseFloatVector
-    Int8Vector / Geometry / Text / ArrayOfVector
+    Int8Vector / Text / ArrayOfVector
 
 Two functions:
 
@@ -61,6 +61,7 @@ _SCALAR_TYPE_TO_SLOT: Dict[int, str] = {
     11: "double_data",   # Double
     21: "string_data",   # VarChar
     23: "json_data",     # JSON
+    24: "string_data",   # Geometry WKT
     26: "string_data",   # Timestamptz. pymilvus sends/parses it as string_data.
 }
 
@@ -616,6 +617,7 @@ _LITEVECDB_TO_MILVUS_INT: Dict[DataType, int] = {
     DataType.VARCHAR: 21,
     DataType.ARRAY:   22,
     DataType.JSON:    23,
+    DataType.GEOMETRY: 24,
     DataType.TIMESTAMPTZ: 26,
     DataType.FLOAT_VECTOR: 101,
     DataType.SPARSE_FLOAT_VECTOR: 104,
@@ -633,7 +635,7 @@ def _default_for(dtype: DataType) -> Any:
         return 0
     if dtype in (DataType.FLOAT, DataType.DOUBLE):
         return 0.0
-    if dtype == DataType.VARCHAR:
+    if dtype in (DataType.VARCHAR, DataType.GEOMETRY):
         return ""
     return None
 
@@ -648,6 +650,6 @@ def _coerce_for(dtype: DataType, v: Any) -> Any:
         return parse_timestamptz(v)
     if dtype in (DataType.FLOAT, DataType.DOUBLE):
         return float(v)
-    if dtype == DataType.VARCHAR:
+    if dtype in (DataType.VARCHAR, DataType.GEOMETRY):
         return str(v)
     return v

--- a/milvus_lite/adapter/grpc/translators/schema.py
+++ b/milvus_lite/adapter/grpc/translators/schema.py
@@ -277,7 +277,7 @@ def _encode_default_value(pf, dtype: DataType, value: object) -> None:
         vd.float_data = float(value)
     elif dtype == DataType.DOUBLE:
         vd.double_data = float(value)
-    elif dtype == DataType.VARCHAR:
+    elif dtype in (DataType.VARCHAR, DataType.GEOMETRY):
         vd.string_data = str(value)
     elif dtype == DataType.TIMESTAMPTZ:
         if hasattr(vd, "timestamptz_data"):

--- a/milvus_lite/adapter/grpc/translators/schema.py
+++ b/milvus_lite/adapter/grpc/translators/schema.py
@@ -15,6 +15,7 @@ Type mapping (MilvusLite ↔ Milvus DataType enum):
     VARCHAR      ↔ VarChar (21)
     BOOL         ↔ Bool (1)
     JSON         ↔ JSON (23)
+    GEOMETRY     ↔ Geometry (24)
     TIMESTAMPTZ  ↔ Timestamptz (26)
     FLOAT_VECTOR ↔ FloatVector (101)
 
@@ -68,6 +69,7 @@ _MILVUS_TO_LITEVECDB: dict[int, DataType] = {
     21: DataType.VARCHAR,        # VarChar
     22: DataType.ARRAY,          # Array
     23: DataType.JSON,           # JSON
+    24: DataType.GEOMETRY,       # Geometry
     26: DataType.TIMESTAMPTZ,    # Timestamptz
     101: DataType.FLOAT_VECTOR,          # FloatVector
     104: DataType.SPARSE_FLOAT_VECTOR,  # SparseFloatVector
@@ -158,7 +160,7 @@ def _decode_field(proto_field: schema_pb2.FieldSchema) -> FieldSchema:
             f"field {proto_field.name!r} uses Milvus type {type_name} "
             f"which MilvusLite does not support. "
             f"Phase 10.2 supports: BOOL, INT8/16/32/64, FLOAT, DOUBLE, "
-            f"VARCHAR, JSON, ARRAY, TIMESTAMPTZ, FLOAT_VECTOR, SPARSE_FLOAT_VECTOR."
+            f"VARCHAR, JSON, ARRAY, GEOMETRY, TIMESTAMPTZ, FLOAT_VECTOR, SPARSE_FLOAT_VECTOR."
         )
 
     dtype = _MILVUS_TO_LITEVECDB[milvus_dtype_int]

--- a/milvus_lite/schema/__init__.py
+++ b/milvus_lite/schema/__init__.py
@@ -11,6 +11,14 @@ from milvus_lite.schema.validation import (
     validate_schema,
 )
 from milvus_lite.schema.persistence import load_schema, save_schema
+from milvus_lite.schema.geometry import (
+    geometry_contains,
+    geometry_dwithin,
+    geometry_intersects,
+    geometry_is_valid,
+    geometry_within,
+    validate_geometry_wkt,
+)
 
 __all__ = [
     "CollectionSchema",
@@ -23,4 +31,10 @@ __all__ = [
     "separate_dynamic_fields",
     "save_schema",
     "load_schema",
+    "validate_geometry_wkt",
+    "geometry_is_valid",
+    "geometry_contains",
+    "geometry_within",
+    "geometry_intersects",
+    "geometry_dwithin",
 ]

--- a/milvus_lite/schema/geometry.py
+++ b/milvus_lite/schema/geometry.py
@@ -61,7 +61,7 @@ def geometry_contains(left: str, right: str) -> bool:
     if isinstance(a, Point) and isinstance(b, Point):
         return a == b
     if isinstance(a, Polygon) and isinstance(b, Polygon):
-        return all(_point_in_polygon(p, a, include_boundary=True) for p in b.points[:-1])
+        return _polygon_contains_polygon(a, b)
     return False
 
 
@@ -223,6 +223,19 @@ def _polygon_polygon_distance(a: Polygon, b: Polygon) -> float:
     )
 
 
+def _polygon_contains_polygon(a: Polygon, b: Polygon) -> bool:
+    if not all(_point_in_polygon(p, a, include_boundary=True) for p in b.points[:-1]):
+        return False
+    for a1, a2 in zip(a.points, a.points[1:]):
+        for b1, b2 in zip(b.points, b.points[1:]):
+            if _segments_intersect(a1, a2, b1, b2):
+                shared_a1 = _points_equal(a1, b1) or _points_equal(a1, b2)
+                shared_a2 = _points_equal(a2, b1) or _points_equal(a2, b2)
+                if not (shared_a1 and shared_a2):
+                    return False
+    return True
+
+
 def _polygons_intersect(a: Polygon, b: Polygon) -> bool:
     a_edges = list(zip(a.points, a.points[1:]))
     b_edges = list(zip(b.points, b.points[1:]))
@@ -247,6 +260,10 @@ def _segments_intersect(a1: Point, a2: Point, b1: Point, b2: Point) -> bool:
     if d4 == 0 and _point_on_segment(a2, b1, b2):
         return True
     return (d1 > 0) != (d2 > 0) and (d3 > 0) != (d4 > 0)
+
+
+def _points_equal(a: Point, b: Point) -> bool:
+    return abs(a.x - b.x) <= 1e-9 and abs(a.y - b.y) <= 1e-9
 
 
 def _orientation(a: Point, b: Point, c: Point) -> int:

--- a/milvus_lite/schema/geometry.py
+++ b/milvus_lite/schema/geometry.py
@@ -226,14 +226,19 @@ def _polygon_polygon_distance(a: Polygon, b: Polygon) -> float:
 def _polygon_contains_polygon(a: Polygon, b: Polygon) -> bool:
     if not all(_point_in_polygon(p, a, include_boundary=True) for p in b.points[:-1]):
         return False
-    for a1, a2 in zip(a.points, a.points[1:]):
-        for b1, b2 in zip(b.points, b.points[1:]):
-            if _segments_intersect(a1, a2, b1, b2):
-                shared_a1 = _points_equal(a1, b1) or _points_equal(a1, b2)
-                shared_a2 = _points_equal(a2, b1) or _points_equal(a2, b2)
-                if not (shared_a1 and shared_a2):
+    for b1, b2 in zip(b.points, b.points[1:]):
+        midpoint = Point((b1.x + b2.x) / 2, (b1.y + b2.y) / 2)
+        if not _point_in_polygon(midpoint, a, include_boundary=True):
+            return False
+        for a1, a2 in zip(a.points, a.points[1:]):
+            if _segments_intersect(a1, a2, b1, b2) and not _segments_collinear(a1, a2, b1, b2):
+                if not _point_on_segment(b1, a1, a2) and not _point_on_segment(b2, a1, a2):
                     return False
     return True
+
+
+def _segments_collinear(a1: Point, a2: Point, b1: Point, b2: Point) -> bool:
+    return _orientation(a1, a2, b1) == 0 and _orientation(a1, a2, b2) == 0
 
 
 def _polygons_intersect(a: Polygon, b: Polygon) -> bool:
@@ -260,10 +265,6 @@ def _segments_intersect(a1: Point, a2: Point, b1: Point, b2: Point) -> bool:
     if d4 == 0 and _point_on_segment(a2, b1, b2):
         return True
     return (d1 > 0) != (d2 > 0) and (d3 > 0) != (d4 > 0)
-
-
-def _points_equal(a: Point, b: Point) -> bool:
-    return abs(a.x - b.x) <= 1e-9 and abs(a.y - b.y) <= 1e-9
 
 
 def _orientation(a: Point, b: Point, c: Point) -> int:

--- a/milvus_lite/schema/geometry.py
+++ b/milvus_lite/schema/geometry.py
@@ -1,0 +1,256 @@
+"""Geometry WKT helpers for the supported spatial filter subset."""
+
+from __future__ import annotations
+
+import math
+import re
+from dataclasses import dataclass
+
+from milvus_lite.exceptions import SchemaValidationError
+
+
+@dataclass(frozen=True)
+class Point:
+    x: float
+    y: float
+
+
+@dataclass(frozen=True)
+class Polygon:
+    points: tuple[Point, ...]
+
+
+Geometry = Point | Polygon
+
+_POINT_RE = re.compile(r"^\s*POINT\s*\(\s*([^\s,()]+)\s+([^\s,()]+)\s*\)\s*$", re.IGNORECASE)
+_POLYGON_RE = re.compile(r"^\s*POLYGON\s*\(\s*\(\s*(.*?)\s*\)\s*\)\s*$", re.IGNORECASE | re.DOTALL)
+
+
+def validate_geometry_wkt(value: str) -> str:
+    parse_wkt(value)
+    return value
+
+
+def geometry_is_valid(value: str) -> bool:
+    try:
+        parse_wkt(value)
+    except SchemaValidationError:
+        return False
+    return True
+
+
+def parse_wkt(value: object) -> Geometry:
+    if not isinstance(value, str):
+        raise SchemaValidationError("GEOMETRY value must be a WKT string")
+    point_match = _POINT_RE.match(value)
+    if point_match:
+        return Point(_parse_float(point_match.group(1), value), _parse_float(point_match.group(2), value))
+    polygon_match = _POLYGON_RE.match(value)
+    if polygon_match:
+        return _parse_polygon(polygon_match.group(1), value)
+    raise SchemaValidationError(
+        "GEOMETRY value must be WKT POINT(x y) or POLYGON((x y, ...))"
+    )
+
+
+def geometry_contains(left: str, right: str) -> bool:
+    a = parse_wkt(left)
+    b = parse_wkt(right)
+    if isinstance(a, Polygon) and isinstance(b, Point):
+        return _point_in_polygon(b, a, include_boundary=True)
+    if isinstance(a, Point) and isinstance(b, Point):
+        return a == b
+    if isinstance(a, Polygon) and isinstance(b, Polygon):
+        return all(_point_in_polygon(p, a, include_boundary=True) for p in b.points[:-1])
+    return False
+
+
+def geometry_within(left: str, right: str) -> bool:
+    return geometry_contains(right, left)
+
+
+def geometry_intersects(left: str, right: str) -> bool:
+    a = parse_wkt(left)
+    b = parse_wkt(right)
+    if isinstance(a, Point) and isinstance(b, Point):
+        return a == b
+    if isinstance(a, Polygon) and isinstance(b, Point):
+        return _point_in_polygon(b, a, include_boundary=True)
+    if isinstance(a, Point) and isinstance(b, Polygon):
+        return _point_in_polygon(a, b, include_boundary=True)
+    if isinstance(a, Polygon) and isinstance(b, Polygon):
+        return _polygons_intersect(a, b)
+    return False
+
+
+def geometry_dwithin(left: str, right: str, distance: float) -> bool:
+    if distance < 0:
+        raise SchemaValidationError("ST_DWITHIN distance must be non-negative")
+    return _geometry_distance(parse_wkt(left), parse_wkt(right)) <= distance + 1e-9
+
+
+def _geometry_distance(a: Geometry, b: Geometry) -> float:
+    if geometry_intersects_wkt(a, b):
+        return 0.0
+    if isinstance(a, Point) and isinstance(b, Point):
+        return _point_distance(a, b)
+    if isinstance(a, Point) and isinstance(b, Polygon):
+        return _point_polygon_distance(a, b)
+    if isinstance(a, Polygon) and isinstance(b, Point):
+        return _point_polygon_distance(b, a)
+    if isinstance(a, Polygon) and isinstance(b, Polygon):
+        return _polygon_polygon_distance(a, b)
+    return math.inf
+
+
+def geometry_intersects_wkt(a: Geometry, b: Geometry) -> bool:
+    if isinstance(a, Point) and isinstance(b, Point):
+        return a == b
+    if isinstance(a, Polygon) and isinstance(b, Point):
+        return _point_in_polygon(b, a, include_boundary=True)
+    if isinstance(a, Point) and isinstance(b, Polygon):
+        return _point_in_polygon(a, b, include_boundary=True)
+    if isinstance(a, Polygon) and isinstance(b, Polygon):
+        return _polygons_intersect(a, b)
+    return False
+
+
+def _parse_polygon(body: str, original: str) -> Polygon:
+    points: list[Point] = []
+    for part in body.split(","):
+        coords = part.strip().split()
+        if len(coords) != 2:
+            raise SchemaValidationError(
+                "GEOMETRY POLYGON coordinates must be pairs of x y values"
+            )
+        points.append(Point(_parse_float(coords[0], original), _parse_float(coords[1], original)))
+    if len(points) < 4:
+        raise SchemaValidationError("GEOMETRY POLYGON requires at least 4 coordinate pairs")
+    if points[0] != points[-1]:
+        raise SchemaValidationError("GEOMETRY POLYGON ring must be closed")
+    polygon = Polygon(tuple(points))
+    _validate_simple_polygon(polygon)
+    return polygon
+
+
+def _parse_float(raw: str, original: str) -> float:
+    try:
+        value = float(raw)
+    except ValueError as e:
+        raise SchemaValidationError(f"GEOMETRY value {original!r} has non-numeric coordinate {raw!r}") from e
+    if not math.isfinite(value):
+        raise SchemaValidationError(f"GEOMETRY value {original!r} has non-finite coordinate {raw!r}")
+    return value
+
+
+def _validate_simple_polygon(polygon: Polygon) -> None:
+    edges = list(zip(polygon.points, polygon.points[1:]))
+    last = len(edges) - 1
+    for i, (a1, a2) in enumerate(edges):
+        for j in range(i + 1, len(edges)):
+            b1, b2 = edges[j]
+            if abs(i - j) <= 1:
+                continue
+            if i == 0 and j == last:
+                continue
+            if _segments_intersect(a1, a2, b1, b2):
+                raise SchemaValidationError("GEOMETRY POLYGON ring must not self-intersect")
+
+
+def _point_in_polygon(point: Point, polygon: Polygon, include_boundary: bool) -> bool:
+    inside = False
+    pts = polygon.points
+    j = len(pts) - 1
+    for i, pi in enumerate(pts):
+        pj = pts[j]
+        if _point_on_segment(point, pj, pi):
+            return include_boundary
+        if (pi.y > point.y) != (pj.y > point.y):
+            x_intersect = (pj.x - pi.x) * (point.y - pi.y) / (pj.y - pi.y) + pi.x
+            if point.x < x_intersect:
+                inside = not inside
+        j = i
+    return inside
+
+
+def _point_on_segment(p: Point, a: Point, b: Point) -> bool:
+    cross = (p.y - a.y) * (b.x - a.x) - (p.x - a.x) * (b.y - a.y)
+    if abs(cross) > 1e-9:
+        return False
+    return min(a.x, b.x) - 1e-9 <= p.x <= max(a.x, b.x) + 1e-9 and min(a.y, b.y) - 1e-9 <= p.y <= max(a.y, b.y) + 1e-9
+
+
+def _point_distance(a: Point, b: Point) -> float:
+    return math.hypot(a.x - b.x, a.y - b.y)
+
+
+def _point_segment_distance(p: Point, a: Point, b: Point) -> float:
+    dx = b.x - a.x
+    dy = b.y - a.y
+    if abs(dx) <= 1e-12 and abs(dy) <= 1e-12:
+        return _point_distance(p, a)
+    t = ((p.x - a.x) * dx + (p.y - a.y) * dy) / (dx * dx + dy * dy)
+    t = max(0.0, min(1.0, t))
+    projected = Point(a.x + t * dx, a.y + t * dy)
+    return _point_distance(p, projected)
+
+
+def _point_polygon_distance(point: Point, polygon: Polygon) -> float:
+    if _point_in_polygon(point, polygon, include_boundary=True):
+        return 0.0
+    return min(
+        _point_segment_distance(point, a, b)
+        for a, b in zip(polygon.points, polygon.points[1:])
+    )
+
+
+def _segment_segment_distance(a1: Point, a2: Point, b1: Point, b2: Point) -> float:
+    if _segments_intersect(a1, a2, b1, b2):
+        return 0.0
+    return min(
+        _point_segment_distance(a1, b1, b2),
+        _point_segment_distance(a2, b1, b2),
+        _point_segment_distance(b1, a1, a2),
+        _point_segment_distance(b2, a1, a2),
+    )
+
+
+def _polygon_polygon_distance(a: Polygon, b: Polygon) -> float:
+    return min(
+        _segment_segment_distance(a1, a2, b1, b2)
+        for a1, a2 in zip(a.points, a.points[1:])
+        for b1, b2 in zip(b.points, b.points[1:])
+    )
+
+
+def _polygons_intersect(a: Polygon, b: Polygon) -> bool:
+    a_edges = list(zip(a.points, a.points[1:]))
+    b_edges = list(zip(b.points, b.points[1:]))
+    for a1, a2 in a_edges:
+        for b1, b2 in b_edges:
+            if _segments_intersect(a1, a2, b1, b2):
+                return True
+    return _point_in_polygon(a.points[0], b, include_boundary=True) or _point_in_polygon(b.points[0], a, include_boundary=True)
+
+
+def _segments_intersect(a1: Point, a2: Point, b1: Point, b2: Point) -> bool:
+    d1 = _orientation(a1, a2, b1)
+    d2 = _orientation(a1, a2, b2)
+    d3 = _orientation(b1, b2, a1)
+    d4 = _orientation(b1, b2, a2)
+    if d1 == 0 and _point_on_segment(b1, a1, a2):
+        return True
+    if d2 == 0 and _point_on_segment(b2, a1, a2):
+        return True
+    if d3 == 0 and _point_on_segment(a1, b1, b2):
+        return True
+    if d4 == 0 and _point_on_segment(a2, b1, b2):
+        return True
+    return (d1 > 0) != (d2 > 0) and (d3 > 0) != (d4 > 0)
+
+
+def _orientation(a: Point, b: Point, c: Point) -> int:
+    value = (b.x - a.x) * (c.y - a.y) - (b.y - a.y) * (c.x - a.x)
+    if abs(value) <= 1e-9:
+        return 0
+    return 1 if value > 0 else -1

--- a/milvus_lite/schema/types.py
+++ b/milvus_lite/schema/types.py
@@ -20,6 +20,7 @@ class DataType(Enum):
     VARCHAR = "varchar"
     JSON = "json"
     ARRAY = "array"
+    GEOMETRY = "geometry"
     TIMESTAMPTZ = "timestamptz"
     FLOAT_VECTOR = "float_vector"
     SPARSE_FLOAT_VECTOR = "sparse_float_vector"
@@ -89,6 +90,7 @@ TYPE_MAP: Dict[DataType, Any] = {
     DataType.VARCHAR: pa.string(),
     DataType.JSON: pa.string(),
     DataType.ARRAY: None,  # resolved at runtime from element_type
+    DataType.GEOMETRY: pa.string(),
     DataType.TIMESTAMPTZ: pa.timestamp("us", tz="UTC"),
     DataType.FLOAT_VECTOR: None,
     DataType.SPARSE_FLOAT_VECTOR: pa.binary(),

--- a/milvus_lite/schema/validation.py
+++ b/milvus_lite/schema/validation.py
@@ -13,6 +13,7 @@ from milvus_lite.schema.types import (
     Function,
     FunctionType,
 )
+from milvus_lite.schema.geometry import validate_geometry_wkt
 from milvus_lite.schema.timestamptz import parse_timestamptz, validate_timezone_name
 
 # Reserved column names — users may not name fields these.
@@ -45,6 +46,7 @@ _DTYPE_PYTHON_CHECK = {
     DataType.DOUBLE: lambda v: isinstance(v, (int, float)) and not isinstance(v, bool),
     DataType.VARCHAR: lambda v: isinstance(v, str),
     DataType.JSON: lambda v: isinstance(v, (dict, list, str, int, float, bool)) or v is None,
+    DataType.GEOMETRY: lambda v: isinstance(v, str),
     DataType.TIMESTAMPTZ: lambda v: isinstance(v, int) and not isinstance(v, bool),
 }
 
@@ -124,6 +126,13 @@ def validate_schema(
                 f.default_value,
                 default_timezone=default_timezone,
             )
+        if f.dtype == DataType.GEOMETRY and f.default_value is not None:
+            try:
+                validate_geometry_wkt(f.default_value)
+            except SchemaValidationError as e:
+                raise SchemaValidationError(
+                    f"GEOMETRY field {f.name!r} default_value is invalid"
+                ) from e
 
     if len(pk_fields) == 0:
         raise SchemaValidationError("schema has no primary key field")
@@ -427,6 +436,13 @@ def validate_record(
                     f"field {f.name!r} value {value!r} does not match dtype {f.dtype}"
                 ) from e
             value = record[f.name]
+        if f.dtype == DataType.GEOMETRY:
+            try:
+                validate_geometry_wkt(value)
+            except SchemaValidationError as e:
+                raise SchemaValidationError(
+                    f"field {f.name!r} value {value!r} does not match dtype {f.dtype}"
+                ) from e
         # VARCHAR max_length check
         if f.dtype == DataType.VARCHAR and f.max_length is not None:
             if isinstance(value, str) and len(value) > f.max_length:

--- a/milvus_lite/search/filter/ast.py
+++ b/milvus_lite/search/filter/ast.py
@@ -227,6 +227,31 @@ class TextMatchOp:
     pos: int
 
 
+@dataclass(frozen=True)
+class GeometryOp:
+    """``geometry_contains/within/intersects(field, 'WKT')`` spatial predicate."""
+    op: str
+    field: FieldRef
+    geometry: StringLit
+    pos: int
+
+
+@dataclass(frozen=True)
+class GeometryIsValidOp:
+    """``ST_ISVALID(field)`` spatial predicate."""
+    field: FieldRef
+    pos: int
+
+
+@dataclass(frozen=True)
+class GeometryDWithinOp:
+    """``ST_DWITHIN(field, 'WKT', distance)`` spatial predicate."""
+    field: FieldRef
+    geometry: StringLit
+    distance: Union[IntLit, FloatLit]
+    pos: int
+
+
 # ── Array filter functions ────────────────────────────────────────────────
 
 @dataclass(frozen=True)
@@ -262,6 +287,6 @@ Expr = Union[
     CmpOp, InOp, And, Or, Not,
     ArithOp, LikeOp, IsNullOp,
     MetaAccess, JsonAccess,
-    TextMatchOp,
+    TextMatchOp, GeometryOp, GeometryIsValidOp, GeometryDWithinOp,
     ArrayContainsOp, ArrayLengthOp, ArrayAccessOp,
 ]

--- a/milvus_lite/search/filter/eval/python_backend.py
+++ b/milvus_lite/search/filter/eval/python_backend.py
@@ -26,6 +26,9 @@ from milvus_lite.search.filter.ast import (
     CmpOp,
     FieldRef,
     FloatLit,
+    GeometryOp,
+    GeometryDWithinOp,
+    GeometryIsValidOp,
     InOp,
     IntLit,
     IntervalLit,
@@ -275,6 +278,48 @@ def _eval_row(node, row: dict) -> Any:
             return False
         # OR logic: match if any query token is in doc tokens
         return bool(doc_tokens & query_tokens)
+
+    # ── Geometry functions ──────────────────────────────────────
+    if isinstance(node, GeometryOp):
+        field_val = row.get(node.field.name)
+        if field_val is None:
+            return False
+        from milvus_lite.schema.geometry import (
+            geometry_contains,
+            geometry_intersects,
+            geometry_within,
+        )
+        try:
+            if node.op == "geometry_contains":
+                return geometry_contains(field_val, node.geometry.value)
+            if node.op == "geometry_within":
+                return geometry_within(field_val, node.geometry.value)
+            if node.op == "geometry_intersects":
+                return geometry_intersects(field_val, node.geometry.value)
+        except Exception:
+            return False
+        return False
+
+    if isinstance(node, GeometryIsValidOp):
+        field_val = row.get(node.field.name)
+        if field_val is None:
+            return False
+        from milvus_lite.schema.geometry import geometry_is_valid
+        return geometry_is_valid(field_val)
+
+    if isinstance(node, GeometryDWithinOp):
+        field_val = row.get(node.field.name)
+        if field_val is None:
+            return False
+        from milvus_lite.schema.geometry import geometry_dwithin
+        try:
+            return geometry_dwithin(
+                field_val,
+                node.geometry.value,
+                float(node.distance.value),
+            )
+        except Exception:
+            return False
 
     # ── Array functions ─────────────────────────────────────────
     if isinstance(node, ArrayContainsOp):

--- a/milvus_lite/search/filter/parser.py
+++ b/milvus_lite/search/filter/parser.py
@@ -31,8 +31,8 @@ from milvus_lite.search.filter.ast import (
     BoolLit,
     CmpOp,
     Expr,
-    FieldRef,
     FloatLit,
+    FieldRef,
     InOp,
     IntLit,
     IntervalLit,
@@ -315,6 +315,105 @@ class Parser:
         self._consume()
         return TextMatchOp(field=field, query=query, pos=func_tok.pos)
 
+    def _parse_geometry_field_arg(self, func_tok: Token) -> FieldRef:
+        field_tok = self._peek()
+        if field_tok.kind != TokenKind.IDENT:
+            raise FilterParseError(
+                f"{func_tok.text}: expected geometry field name",
+                self.source, field_tok.pos,
+            )
+        self._consume()
+        return FieldRef(name=field_tok.text, pos=field_tok.pos)
+
+    def _parse_geometry_predicate(self, func_tok: Token, op: str) -> Expr:
+        """``geometry_contains(field, 'WKT')`` and related predicates."""
+        from milvus_lite.search.filter.ast import GeometryOp
+
+        self._consume()  # '('
+        field = self._parse_geometry_field_arg(func_tok)
+        if self._peek().kind != TokenKind.COMMA:
+            raise FilterParseError(
+                f"{func_tok.text}: expected ',' after field name",
+                self.source, self._peek().pos,
+            )
+        self._consume()
+        geom_tok = self._peek()
+        if geom_tok.kind != TokenKind.STRING:
+            raise FilterParseError(
+                f"{func_tok.text}: expected WKT string literal",
+                self.source, geom_tok.pos,
+            )
+        self._consume()
+        geometry = StringLit(value=geom_tok.value, pos=geom_tok.pos)
+        if self._peek().kind != TokenKind.RPAREN:
+            raise FilterParseError(
+                f"{func_tok.text}: expected ')'",
+                self.source, self._peek().pos,
+            )
+        self._consume()
+        return GeometryOp(op=op, field=field, geometry=geometry, pos=func_tok.pos)
+
+    def _parse_geometry_isvalid(self, func_tok: Token) -> Expr:
+        from milvus_lite.search.filter.ast import GeometryIsValidOp
+
+        self._consume()  # '('
+        field = self._parse_geometry_field_arg(func_tok)
+        if self._peek().kind != TokenKind.RPAREN:
+            raise FilterParseError(
+                f"{func_tok.text}: expected ')'",
+                self.source, self._peek().pos,
+            )
+        self._consume()
+        return GeometryIsValidOp(field=field, pos=func_tok.pos)
+
+    def _parse_geometry_dwithin(self, func_tok: Token) -> Expr:
+        from milvus_lite.search.filter.ast import GeometryDWithinOp
+
+        self._consume()  # '('
+        field = self._parse_geometry_field_arg(func_tok)
+        if self._peek().kind != TokenKind.COMMA:
+            raise FilterParseError(
+                f"{func_tok.text}: expected ',' after field name",
+                self.source, self._peek().pos,
+            )
+        self._consume()
+        geom_tok = self._peek()
+        if geom_tok.kind != TokenKind.STRING:
+            raise FilterParseError(
+                f"{func_tok.text}: expected WKT string literal",
+                self.source, geom_tok.pos,
+            )
+        self._consume()
+        if self._peek().kind != TokenKind.COMMA:
+            raise FilterParseError(
+                f"{func_tok.text}: expected ',' after WKT string",
+                self.source, self._peek().pos,
+            )
+        self._consume()
+        distance = self.parse_unary()
+        if not isinstance(distance, (IntLit, FloatLit)):
+            raise FilterParseError(
+                f"{func_tok.text}: expected numeric distance literal",
+                self.source, getattr(distance, "pos", func_tok.pos),
+            )
+        if distance.value < 0:
+            raise FilterParseError(
+                f"{func_tok.text}: distance must be non-negative",
+                self.source, distance.pos,
+            )
+        if self._peek().kind != TokenKind.RPAREN:
+            raise FilterParseError(
+                f"{func_tok.text}: expected ')'",
+                self.source, self._peek().pos,
+            )
+        self._consume()
+        return GeometryDWithinOp(
+            field=field,
+            geometry=StringLit(value=geom_tok.value, pos=geom_tok.pos),
+            distance=distance,
+            pos=func_tok.pos,
+        )
+
     def _parse_bracket_access(self, ident_tok: Token) -> Expr:
         """``field["key"]``, ``field["a"]["b"]`` (JSON path) or ``field[N]`` (array index).
 
@@ -483,6 +582,20 @@ class Parser:
                 fn_name = tok.text.lower()
                 if fn_name == "text_match":
                     return self._parse_text_match(tok)
+                geometry_aliases = {
+                    "geometry_contains": "geometry_contains",
+                    "geometry_within": "geometry_within",
+                    "geometry_intersects": "geometry_intersects",
+                    "st_contains": "geometry_contains",
+                    "st_within": "geometry_within",
+                    "st_intersects": "geometry_intersects",
+                }
+                if fn_name in geometry_aliases:
+                    return self._parse_geometry_predicate(tok, geometry_aliases[fn_name])
+                if fn_name in ("st_isvalid", "geometry_isvalid"):
+                    return self._parse_geometry_isvalid(tok)
+                if fn_name in ("st_dwithin", "geometry_dwithin"):
+                    return self._parse_geometry_dwithin(tok)
                 if fn_name in ("array_contains", "json_contains"):
                     return self._parse_array_contains(tok, "any_one")
                 if fn_name in ("array_contains_all", "json_contains_all"):
@@ -494,8 +607,10 @@ class Parser:
                 raise FilterParseError(
                     f"unknown function {tok.text!r}",
                     self.source, tok.pos, span=len(tok.text),
-                    hint="supported: text_match, array_contains, json_contains, "
-                         "array_contains_all, array_contains_any, array_length",
+                    hint="supported: text_match, geometry_contains, geometry_within, "
+                         "geometry_intersects, ST_CONTAINS, ST_WITHIN, ST_INTERSECTS, "
+                         "ST_ISVALID, ST_DWITHIN, array_contains, json_contains, array_contains_all, "
+                         "array_contains_any, array_length",
                 )
             # field[...] access: JSON path or array index
             if self._peek().kind == TokenKind.LBRACKET:

--- a/milvus_lite/search/filter/semantic.py
+++ b/milvus_lite/search/filter/semantic.py
@@ -25,6 +25,9 @@ from milvus_lite.search.filter.ast import (
     Expr,
     FieldRef,
     FloatLit,
+    GeometryOp,
+    GeometryDWithinOp,
+    GeometryIsValidOp,
     InOp,
     IntLit,
     IntervalLit,
@@ -60,12 +63,13 @@ SEM_STRING = "string"
 SEM_BOOL = "bool"
 SEM_TIMESTAMPTZ = "timestamptz"
 SEM_INTERVAL = "interval"
+SEM_GEOMETRY = "geometry"
 # Phase F2b: $meta["key"] returns a value whose type is unknown until
 # runtime. SEM_DYNAMIC is compatible with any other type for the purpose
 # of comparisons / IN / arithmetic — runtime semantics decide.
 SEM_DYNAMIC = "dynamic"
 
-_SEM_TYPES = {SEM_INT, SEM_FLOAT, SEM_STRING, SEM_BOOL, SEM_TIMESTAMPTZ, SEM_INTERVAL, SEM_DYNAMIC}
+_SEM_TYPES = {SEM_INT, SEM_FLOAT, SEM_STRING, SEM_BOOL, SEM_TIMESTAMPTZ, SEM_INTERVAL, SEM_GEOMETRY, SEM_DYNAMIC}
 
 # Reserved field names that must not be referenced from filter expressions.
 _RESERVED_FIELDS = frozenset({"_seq", "_partition", "$meta"})
@@ -80,6 +84,8 @@ def _datatype_to_sem(dtype: DataType) -> Optional[str]:
         return SEM_FLOAT
     if dtype == DataType.VARCHAR:
         return SEM_STRING
+    if dtype == DataType.GEOMETRY:
+        return SEM_GEOMETRY
     if dtype == DataType.BOOL:
         return SEM_BOOL
     if dtype == DataType.TIMESTAMPTZ:
@@ -252,6 +258,7 @@ def compile_expr(
         source=source,
         enable_dynamic_field=schema.enable_dynamic_field,
         has_meta_access=False,
+        requires_python=False,
     )
 
     # Walk the AST: type-check + collect referenced fields.
@@ -268,9 +275,8 @@ def compile_expr(
     #   - "arrow"  for pure schema field expressions (fast path)
     #   - "hybrid" for $meta expressions (per-batch JSON preprocessing
     #     then arrow path; ~10x faster than pure row-wise python)
-    #   - "python" reserved for future UDF / truly dynamic things that
-    #     hybrid can't handle. Not selected automatically in F3+.
-    backend = "hybrid" if ctx.has_meta_access else "arrow"
+    #   - "python" for row-wise functions that have no Arrow kernel.
+    backend = "python" if ctx.requires_python else "hybrid" if ctx.has_meta_access else "arrow"
 
     return CompiledExpr(
         ast=expr,
@@ -290,6 +296,7 @@ class _CompileCtx:
     source: str
     enable_dynamic_field: bool
     has_meta_access: bool
+    requires_python: bool
 
 
 # ---------------------------------------------------------------------------
@@ -480,6 +487,40 @@ def _check_node(node: Expr, ctx: "_CompileCtx") -> str:
     if isinstance(node, TextMatchOp):
         _check_node(node.field, ctx)
         ctx.has_meta_access = True
+        return SEM_BOOL
+
+    # ── Geometry functions ───────────────────────────────────
+    if isinstance(node, GeometryOp):
+        field_type = _check_node(node.field, ctx)
+        if field_type != SEM_GEOMETRY:
+            raise FilterTypeError(
+                f"{node.op} requires a GEOMETRY field, got "
+                f"{_describe_operand(node.field, field_type)}",
+                ctx.source, node.pos,
+            )
+        ctx.requires_python = True
+        return SEM_BOOL
+
+    if isinstance(node, GeometryIsValidOp):
+        field_type = _check_node(node.field, ctx)
+        if field_type != SEM_GEOMETRY:
+            raise FilterTypeError(
+                f"ST_ISVALID requires a GEOMETRY field, got "
+                f"{_describe_operand(node.field, field_type)}",
+                ctx.source, node.pos,
+            )
+        ctx.requires_python = True
+        return SEM_BOOL
+
+    if isinstance(node, GeometryDWithinOp):
+        field_type = _check_node(node.field, ctx)
+        if field_type != SEM_GEOMETRY:
+            raise FilterTypeError(
+                f"ST_DWITHIN requires a GEOMETRY field, got "
+                f"{_describe_operand(node.field, field_type)}",
+                ctx.source, node.pos,
+            )
+        ctx.requires_python = True
         return SEM_BOOL
 
     # ── Array functions ──────────────────────────────────────

--- a/milvus_lite/search/filter/semantic.py
+++ b/milvus_lite/search/filter/semantic.py
@@ -46,6 +46,8 @@ from milvus_lite.search.filter.ast import (
     ArrayLengthOp,
     ArrayAccessOp,
 )
+from milvus_lite.exceptions import SchemaValidationError
+from milvus_lite.schema import validate_geometry_wkt
 from milvus_lite.search.filter.exceptions import (
     FilterFieldError,
     FilterTypeError,
@@ -498,6 +500,7 @@ def _check_node(node: Expr, ctx: "_CompileCtx") -> str:
                 f"{_describe_operand(node.field, field_type)}",
                 ctx.source, node.pos,
             )
+        _validate_geometry_literal(node.geometry, ctx)
         ctx.requires_python = True
         return SEM_BOOL
 
@@ -520,6 +523,7 @@ def _check_node(node: Expr, ctx: "_CompileCtx") -> str:
                 f"{_describe_operand(node.field, field_type)}",
                 ctx.source, node.pos,
             )
+        _validate_geometry_literal(node.geometry, ctx)
         ctx.requires_python = True
         return SEM_BOOL
 
@@ -546,6 +550,17 @@ def _check_node(node: Expr, ctx: "_CompileCtx") -> str:
         return SEM_DYNAMIC
 
     raise TypeError(f"unknown AST node type: {type(node).__name__}")
+
+
+def _validate_geometry_literal(node: StringLit, ctx: "_CompileCtx") -> None:
+    try:
+        validate_geometry_wkt(node.value)
+    except SchemaValidationError as e:
+        raise FilterTypeError(
+            "geometry predicate requires a valid WKT literal",
+            ctx.source,
+            node.pos,
+        ) from e
 
 
 def _describe_operand(node: Expr, sem_type: str) -> str:

--- a/tests/adapter/test_grpc_geometry.py
+++ b/tests/adapter/test_grpc_geometry.py
@@ -1,0 +1,193 @@
+"""pymilvus GEOMETRY compatibility tests.
+
+Migrated and reduced from Milvus python_client geometry coverage. MilvusLite
+currently supports WKT POINT/simple POLYGON plus ST_CONTAINS, ST_WITHIN,
+ST_INTERSECTS, ST_DWITHIN, and ST_ISVALID.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("pymilvus")
+from pymilvus import DataType, MilvusClient  # noqa: E402
+
+
+GEOMETRY = getattr(DataType, "GEOMETRY", None)
+pytestmark = pytest.mark.skipif(GEOMETRY is None, reason="pymilvus lacks GEOMETRY DataType")
+
+DIM = 2
+PK = "id"
+VEC = "vector"
+GEO = "geo"
+_MISSING = object()
+
+
+def _schema(nullable: bool = False, default_value=_MISSING):
+    schema = MilvusClient.create_schema(auto_id=False, enable_dynamic_field=False)
+    schema.add_field(PK, DataType.INT64, is_primary=True)
+    schema.add_field(VEC, DataType.FLOAT_VECTOR, dim=DIM)
+    kwargs = {"nullable": nullable}
+    if default_value is not _MISSING:
+        kwargs["default_value"] = default_value
+    schema.add_field(GEO, GEOMETRY, **kwargs)
+    return schema
+
+
+def _vector_index(client: MilvusClient):
+    index = client.prepare_index_params()
+    index.add_index(
+        field_name=VEC,
+        index_type="BRUTE_FORCE",
+        metric_type="L2",
+        params={},
+    )
+    return index
+
+
+def _rows():
+    return [
+        {PK: 1, VEC: [0.0, 0.0], GEO: "POINT(1 1)"},
+        {PK: 2, VEC: [1.0, 0.0], GEO: "POINT(20 20)"},
+        {PK: 3, VEC: [0.0, 1.0], GEO: "POLYGON((0 0, 10 0, 10 10, 0 10, 0 0))"},
+    ]
+
+
+def _by_id(rows):
+    return {row[PK]: row for row in rows}
+
+
+def test_milvus_client_geometry_create_insert_query(milvus_client):
+    collection = "geo_basic"
+    milvus_client.create_collection(collection, schema=_schema())
+    milvus_client.insert(collection, _rows())
+
+    rows = milvus_client.query(
+        collection,
+        filter="id >= 0",
+        output_fields=[PK, GEO],
+    )
+
+    got = _by_id(rows)
+    assert got[1][GEO] == "POINT(1 1)"
+    assert got[2][GEO] == "POINT(20 20)"
+    assert got[3][GEO] == "POLYGON((0 0, 10 0, 10 10, 0 10, 0 0))"
+
+
+def test_milvus_client_geometry_spatial_predicates(milvus_client):
+    collection = "geo_predicates"
+    milvus_client.create_collection(collection, schema=_schema())
+    milvus_client.insert(collection, _rows())
+
+    rows = milvus_client.query(
+        collection,
+        filter="ST_WITHIN(geo, 'POLYGON((0 0, 10 0, 10 10, 0 10, 0 0))')",
+        output_fields=[PK, GEO],
+    )
+    assert sorted(row[PK] for row in rows) == [1, 3]
+
+    rows = milvus_client.query(
+        collection,
+        filter="ST_CONTAINS(geo, 'POINT(5 5)')",
+        output_fields=[PK, GEO],
+    )
+    assert [row[PK] for row in rows] == [3]
+
+    rows = milvus_client.query(
+        collection,
+        filter="ST_INTERSECTS(geo, 'POINT(0 5)')",
+        output_fields=[PK, GEO],
+    )
+    assert [row[PK] for row in rows] == [3]
+
+
+def test_milvus_client_geometry_search_filter(milvus_client):
+    collection = "geo_search"
+    milvus_client.create_collection(collection, schema=_schema())
+    milvus_client.insert(collection, _rows())
+    milvus_client.create_index(collection, _vector_index(milvus_client))
+    milvus_client.load_collection(collection)
+
+    results = milvus_client.search(
+        collection,
+        data=[[0.0, 0.0]],
+        limit=10,
+        filter="ST_WITHIN(geo, 'POLYGON((0 0, 10 0, 10 10, 0 10, 0 0))')",
+        output_fields=[GEO],
+    )
+
+    assert len(results) == 1
+    assert sorted(hit[PK] for hit in results[0]) == [1, 3]
+    entities = {hit[PK]: hit["entity"] for hit in results[0]}
+    assert entities[1][GEO] == "POINT(1 1)"
+    assert entities[3][GEO] == "POLYGON((0 0, 10 0, 10 10, 0 10, 0 0))"
+
+
+def test_milvus_client_geometry_nullable_and_isvalid(milvus_client):
+    collection = "geo_nullable"
+    milvus_client.create_collection(collection, schema=_schema(nullable=True))
+    milvus_client.insert(collection, [
+        {PK: 1, VEC: [0.0, 0.0], GEO: "POINT(1 1)"},
+        {PK: 2, VEC: [1.0, 0.0], GEO: None},
+    ])
+
+    rows = milvus_client.query(collection, filter="geo is null", output_fields=[PK, GEO])
+    assert rows == [{PK: 2, GEO: None}]
+
+    rows = milvus_client.query(collection, filter="ST_ISVALID(geo)", output_fields=[PK, GEO])
+    assert rows == [{PK: 1, GEO: "POINT(1 1)"}]
+
+
+def test_milvus_client_geometry_default_value(milvus_client):
+    collection = "geo_default"
+    milvus_client.create_collection(collection, schema=_schema(default_value="POINT(0 0)"))
+    milvus_client.insert(collection, [
+        {PK: 1, VEC: [0.0, 0.0]},
+        {PK: 2, VEC: [1.0, 0.0], GEO: None},
+        {PK: 3, VEC: [0.0, 1.0], GEO: "POINT(2 2)"},
+    ])
+
+    rows = milvus_client.query(collection, filter="id >= 0", output_fields=[PK, GEO])
+    got = _by_id(rows)
+    assert got[1][GEO] == "POINT(0 0)"
+    assert got[2][GEO] == "POINT(0 0)"
+    assert got[3][GEO] == "POINT(2 2)"
+
+
+def test_milvus_client_geometry_dwithin(milvus_client):
+    collection = "geo_dwithin"
+    milvus_client.create_collection(collection, schema=_schema())
+    milvus_client.insert(collection, [
+        {PK: 1, VEC: [0.0, 0.0], GEO: "POINT(1 1)"},
+        {PK: 2, VEC: [1.0, 0.0], GEO: "POINT(4 5)"},
+        {PK: 3, VEC: [0.0, 1.0], GEO: "POINT(10 10)"},
+    ])
+
+    rows = milvus_client.query(
+        collection,
+        filter="ST_DWITHIN(geo, 'POINT(1 1)', 5)",
+        output_fields=[PK, GEO],
+    )
+
+    assert sorted(row[PK] for row in rows) == [1, 2]
+
+
+def test_milvus_client_geometry_invalid_wkt_rejected(milvus_client):
+    collection = "geo_invalid_wkt"
+    milvus_client.create_collection(collection, schema=_schema())
+
+    with pytest.raises(Exception, match="GEOMETRY|WKT|syntax|parse"):
+        milvus_client.insert(collection, [{PK: 1, VEC: [0.0, 0.0], GEO: "not-wkt"}])
+
+
+def test_milvus_client_geometry_filter_on_non_geometry_field_rejected(milvus_client):
+    schema = MilvusClient.create_schema(auto_id=False, enable_dynamic_field=False)
+    schema.add_field(PK, DataType.INT64, is_primary=True)
+    schema.add_field(VEC, DataType.FLOAT_VECTOR, dim=DIM)
+    schema.add_field("name", DataType.VARCHAR, max_length=64)
+    collection = "geo_wrong_field"
+    milvus_client.create_collection(collection, schema=schema)
+    milvus_client.insert(collection, [{PK: 1, VEC: [0.0, 0.0], "name": "POINT(1 1)"}])
+
+    with pytest.raises(Exception, match="GEOMETRY|geometry|parse|plan"):
+        milvus_client.query(collection, filter="ST_WITHIN(name, 'POINT(1 1)')")

--- a/tests/adapter/test_grpc_translators_records.py
+++ b/tests/adapter/test_grpc_translators_records.py
@@ -175,6 +175,14 @@ def test_decode_unsupported_vector_type_raises():
 
 
 def test_decode_geometry_scalar():
+    fd = _scalar_fd("geo", 24, "geometry_wkt_data", ["POINT(1 2)"])
+
+    records = fields_data_to_records([fd], num_rows=1)
+
+    assert records == [{"geo": "POINT(1 2)"}]
+
+
+def test_decode_geometry_scalar_legacy_string_slot():
     fd = _scalar_fd("geo", 24, "string_data", ["POINT(1 2)"])
 
     records = fields_data_to_records([fd], num_rows=1)
@@ -245,7 +253,7 @@ def test_encode_nullable_geometry_field():
     geo_fd = next(fd for fd in fields_data if fd.field_name == "geo")
     assert geo_fd.type == 24
     assert list(geo_fd.valid_data) == [True, False]
-    assert list(geo_fd.scalars.string_data.data) == ["POINT(1 2)", ""]
+    assert list(geo_fd.scalars.geometry_wkt_data.data) == ["POINT(1 2)", ""]
 
     records = fields_data_to_records(fields_data, num_rows=2)
     assert records[0]["geo"] == "POINT(1 2)"

--- a/tests/adapter/test_grpc_translators_records.py
+++ b/tests/adapter/test_grpc_translators_records.py
@@ -174,13 +174,12 @@ def test_decode_unsupported_vector_type_raises():
         fields_data_to_records([fd], num_rows=1)
 
 
-def test_decode_unsupported_scalar_type_raises():
-    fd = schema_pb2.FieldData()
-    fd.field_name = "geo"
-    fd.type = 24  # Geometry
-    fd.scalars.bytes_data.data.extend([b""])
-    with pytest.raises(SchemaValidationError, match="Geometry"):
-        fields_data_to_records([fd], num_rows=1)
+def test_decode_geometry_scalar():
+    fd = _scalar_fd("geo", 24, "string_data", ["POINT(1 2)"])
+
+    records = fields_data_to_records([fd], num_rows=1)
+
+    assert records == [{"geo": "POINT(1 2)"}]
 
 
 def test_decode_length_mismatch_raises():
@@ -229,6 +228,28 @@ def test_encode_basic_round_trip():
     assert records_out[0]["active"] is True
     assert abs(records_out[0]["score"] - 0.5) < 1e-6
     assert records_out[1]["title"] == "b"
+
+
+def test_encode_nullable_geometry_field():
+    schema = CollectionSchema(fields=[
+        FieldSchema(name="id", dtype=DataType.INT64, is_primary=True),
+        FieldSchema(name="vec", dtype=DataType.FLOAT_VECTOR, dim=2),
+        FieldSchema(name="geo", dtype=DataType.GEOMETRY, nullable=True),
+    ])
+
+    fields_data = records_to_fields_data([
+        {"id": 1, "vec": [0.1, 0.2], "geo": "POINT(1 2)"},
+        {"id": 2, "vec": [0.2, 0.3], "geo": None},
+    ], schema)
+
+    geo_fd = next(fd for fd in fields_data if fd.field_name == "geo")
+    assert geo_fd.type == 24
+    assert list(geo_fd.valid_data) == [True, False]
+    assert list(geo_fd.scalars.string_data.data) == ["POINT(1 2)", ""]
+
+    records = fields_data_to_records(fields_data, num_rows=2)
+    assert records[0]["geo"] == "POINT(1 2)"
+    assert records[1]["geo"] is None
 
 
 def test_encode_timestamptz_round_trip():

--- a/tests/adapter/test_grpc_translators_schema.py
+++ b/tests/adapter/test_grpc_translators_schema.py
@@ -35,6 +35,7 @@ def test_round_trip_all_supported_types():
         FieldSchema(name="i16", dtype=DataType.INT16),
         FieldSchema(name="i32", dtype=DataType.INT32),
         FieldSchema(name="data", dtype=DataType.JSON),
+        FieldSchema(name="shape", dtype=DataType.GEOMETRY),
         FieldSchema(name="tsz", dtype=DataType.TIMESTAMPTZ, nullable=True),
     ])
     proto = milvus_lite_to_milvus_schema("test", schema)

--- a/tests/adapter/test_grpc_translators_schema.py
+++ b/tests/adapter/test_grpc_translators_schema.py
@@ -236,6 +236,18 @@ def test_round_trip_default_value_timestamptz():
     assert by_name["created_at"].default_value > 0
 
 
+def test_round_trip_default_value_geometry():
+    schema = CollectionSchema(fields=[
+        FieldSchema(name="id", dtype=DataType.INT64, is_primary=True),
+        FieldSchema(name="vec", dtype=DataType.FLOAT_VECTOR, dim=4),
+        FieldSchema(name="shape", dtype=DataType.GEOMETRY, default_value="POINT(0 0)"),
+    ])
+    proto = milvus_lite_to_milvus_schema("dv", schema)
+    decoded = milvus_to_milvus_lite_schema(proto)
+    by_name = {f.name: f for f in decoded.fields}
+    assert by_name["shape"].default_value == "POINT(0 0)"
+
+
 def test_round_trip_default_value_bool():
     schema = CollectionSchema(fields=[
         FieldSchema(name="id", dtype=DataType.INT64, is_primary=True),

--- a/tests/engine/test_geometry.py
+++ b/tests/engine/test_geometry.py
@@ -1,0 +1,260 @@
+import pytest
+
+from milvus_lite.engine.collection import Collection
+from milvus_lite.exceptions import SchemaValidationError
+from milvus_lite.schema.types import CollectionSchema, DataType, FieldSchema
+from milvus_lite.search.filter.exceptions import FilterTypeError
+
+
+def _schema(nullable=False):
+    return CollectionSchema(fields=[
+        FieldSchema(name="id", dtype=DataType.INT64, is_primary=True),
+        FieldSchema(name="vec", dtype=DataType.FLOAT_VECTOR, dim=2),
+        FieldSchema(name="shape", dtype=DataType.GEOMETRY, nullable=nullable),
+    ])
+
+
+def test_geometry_query_round_trip(tmp_path):
+    col = Collection("geo", str(tmp_path / "geo"), _schema())
+    col.insert([
+        {"id": 1, "vec": [0.1, 0.2], "shape": "POINT(1 1)"},
+        {"id": 2, "vec": [0.2, 0.3], "shape": "POINT(20 20)"},
+    ])
+
+    rows = col.query(
+        "geometry_within(shape, 'POLYGON((0 0, 10 0, 10 10, 0 10, 0 0))')",
+        output_fields=["shape"],
+    )
+
+    assert rows == [{"id": 1, "shape": "POINT(1 1)"}]
+
+
+def test_geometry_st_alias_query(tmp_path):
+    col = Collection("geo", str(tmp_path / "geo"), _schema())
+    col.insert([
+        {"id": 1, "vec": [0.1, 0.2], "shape": "POINT(1 1)"},
+        {"id": 2, "vec": [0.2, 0.3], "shape": "POINT(20 20)"},
+    ])
+
+    rows = col.query(
+        "ST_WITHIN(shape, 'POLYGON((0 0, 10 0, 10 10, 0 10, 0 0))')",
+        output_fields=["shape"],
+    )
+
+    assert rows == [{"id": 1, "shape": "POINT(1 1)"}]
+
+
+def test_geometry_search_filter(tmp_path):
+    col = Collection("geo", str(tmp_path / "geo"), _schema())
+    col.insert([
+        {"id": 1, "vec": [0.0, 1.0], "shape": "POINT(20 20)"},
+        {"id": 2, "vec": [1.0, 0.0], "shape": "POINT(1 1)"},
+    ])
+
+    results = col.search(
+        [[1.0, 0.0]],
+        top_k=10,
+        metric_type="L2",
+        expr="ST_WITHIN(shape, 'POLYGON((0 0, 10 0, 10 10, 0 10, 0 0))')",
+        output_fields=["shape"],
+    )
+
+    assert [[hit["id"] for hit in hits] for hits in results] == [[2]]
+    assert results[0][0]["entity"] == {"shape": "POINT(1 1)"}
+
+
+def test_geometry_search_output_fields_after_flush(tmp_path):
+    col = Collection("geo", str(tmp_path / "geo"), _schema())
+    col.insert([
+        {"id": 1, "vec": [0.0, 1.0], "shape": "POINT(20 20)"},
+        {"id": 2, "vec": [1.0, 0.0], "shape": "POINT(1 1)"},
+    ])
+    col.flush()
+
+    results = col.search(
+        [[1.0, 0.0]],
+        top_k=1,
+        metric_type="L2",
+        output_fields=["shape"],
+    )
+
+    assert results[0][0]["id"] == 2
+    assert results[0][0]["entity"] == {"shape": "POINT(1 1)"}
+
+
+def test_geometry_multiple_fields(tmp_path):
+    schema = CollectionSchema(fields=[
+        FieldSchema(name="id", dtype=DataType.INT64, is_primary=True),
+        FieldSchema(name="vec", dtype=DataType.FLOAT_VECTOR, dim=2),
+        FieldSchema(name="origin", dtype=DataType.GEOMETRY),
+        FieldSchema(name="area", dtype=DataType.GEOMETRY),
+    ])
+    col = Collection("geo", str(tmp_path / "geo"), schema)
+    col.insert([
+        {
+            "id": 1,
+            "vec": [0.1, 0.2],
+            "origin": "POINT(1 1)",
+            "area": "POLYGON((0 0, 10 0, 10 10, 0 10, 0 0))",
+        },
+        {
+            "id": 2,
+            "vec": [0.2, 0.3],
+            "origin": "POINT(20 20)",
+            "area": "POLYGON((15 15, 30 15, 30 30, 15 30, 15 15))",
+        },
+    ])
+
+    rows = col.query(
+        "ST_CONTAINS(area, 'POINT(5 5)')",
+        output_fields=["origin", "area"],
+    )
+
+    assert rows == [{
+        "id": 1,
+        "origin": "POINT(1 1)",
+        "area": "POLYGON((0 0, 10 0, 10 10, 0 10, 0 0))",
+    }]
+
+
+def test_geometry_nullable_field(tmp_path):
+    col = Collection("geo", str(tmp_path / "geo"), _schema(nullable=True))
+    col.insert([
+        {"id": 1, "vec": [0.1, 0.2], "shape": "POINT(1 1)"},
+        {"id": 2, "vec": [0.2, 0.3], "shape": None},
+    ])
+
+    rows = col.query(
+        "ST_WITHIN(shape, 'POLYGON((0 0, 10 0, 10 10, 0 10, 0 0))')",
+        output_fields=["shape"],
+    )
+
+    assert rows == [{"id": 1, "shape": "POINT(1 1)"}]
+    assert col.get([2])[0]["shape"] is None
+
+
+def test_geometry_combined_scalar_and_spatial_filter(tmp_path):
+    schema = CollectionSchema(fields=[
+        FieldSchema(name="id", dtype=DataType.INT64, is_primary=True),
+        FieldSchema(name="vec", dtype=DataType.FLOAT_VECTOR, dim=2),
+        FieldSchema(name="shape", dtype=DataType.GEOMETRY),
+        FieldSchema(name="city", dtype=DataType.VARCHAR),
+    ])
+    col = Collection("geo", str(tmp_path / "geo"), schema)
+    col.insert([
+        {"id": 1, "vec": [0.1, 0.2], "shape": "POINT(1 1)", "city": "shanghai"},
+        {"id": 2, "vec": [0.2, 0.3], "shape": "POINT(2 2)", "city": "beijing"},
+        {"id": 3, "vec": [0.3, 0.4], "shape": "POINT(20 20)", "city": "shanghai"},
+    ])
+
+    rows = col.query(
+        "city == 'shanghai' and ST_WITHIN(shape, 'POLYGON((0 0, 10 0, 10 10, 0 10, 0 0))')",
+        output_fields=["shape", "city"],
+    )
+
+    assert rows == [{"id": 1, "shape": "POINT(1 1)", "city": "shanghai"}]
+
+
+def test_geometry_dwithin_query(tmp_path):
+    col = Collection("geo", str(tmp_path / "geo"), _schema())
+    col.insert([
+        {"id": 1, "vec": [0.1, 0.2], "shape": "POINT(1 1)"},
+        {"id": 2, "vec": [0.2, 0.3], "shape": "POINT(4 5)"},
+        {"id": 3, "vec": [0.3, 0.4], "shape": "POINT(10 10)"},
+    ])
+
+    rows = col.query("ST_DWITHIN(shape, 'POINT(1 1)', 5)", output_fields=["shape"])
+
+    assert rows == [
+        {"id": 1, "shape": "POINT(1 1)"},
+        {"id": 2, "shape": "POINT(4 5)"},
+    ]
+
+
+def test_geometry_dwithin_polygon_boundary(tmp_path):
+    col = Collection("geo", str(tmp_path / "geo"), _schema())
+    col.insert([
+        {"id": 1, "vec": [0.1, 0.2], "shape": "POLYGON((0 0, 2 0, 2 2, 0 2, 0 0))"},
+        {"id": 2, "vec": [0.2, 0.3], "shape": "POLYGON((10 10, 12 10, 12 12, 10 12, 10 10))"},
+    ])
+
+    rows = col.query("ST_DWITHIN(shape, 'POINT(4 1)', 2)", output_fields=["shape"])
+
+    assert rows == [{
+        "id": 1,
+        "shape": "POLYGON((0 0, 2 0, 2 2, 0 2, 0 0))",
+    }]
+
+
+def test_geometry_isvalid_query(tmp_path):
+    col = Collection("geo", str(tmp_path / "geo"), _schema(nullable=True))
+    col.insert([
+        {"id": 1, "vec": [0.1, 0.2], "shape": "POINT(1 1)"},
+        {"id": 2, "vec": [0.2, 0.3], "shape": None},
+    ])
+
+    rows = col.query("ST_ISVALID(shape)", output_fields=["shape"])
+
+    assert rows == [{"id": 1, "shape": "POINT(1 1)"}]
+
+
+def test_geometry_upsert_and_delete(tmp_path):
+    col = Collection("geo", str(tmp_path / "geo"), _schema())
+    col.insert([
+        {"id": 1, "vec": [0.1, 0.2], "shape": "POINT(20 20)"},
+        {"id": 2, "vec": [0.2, 0.3], "shape": "POINT(5 5)"},
+    ])
+    col.upsert([{"id": 1, "shape": "POINT(1 1)"}])
+    col.delete([2])
+
+    rows = col.query(
+        "ST_WITHIN(shape, 'POLYGON((0 0, 10 0, 10 10, 0 10, 0 0))')",
+        output_fields=["shape"],
+    )
+
+    assert rows == [{"id": 1, "shape": "POINT(1 1)"}]
+
+
+def test_geometry_default_value(tmp_path):
+    schema = CollectionSchema(fields=[
+        FieldSchema(name="id", dtype=DataType.INT64, is_primary=True),
+        FieldSchema(name="vec", dtype=DataType.FLOAT_VECTOR, dim=2),
+        FieldSchema(name="shape", dtype=DataType.GEOMETRY, default_value="POINT(0 0)"),
+    ])
+    col = Collection("geo", str(tmp_path / "geo"), schema)
+    col.insert([{"id": 1, "vec": [0.1, 0.2]}])
+
+    rows = col.query(output_fields=["shape"])
+
+    assert rows == [{"id": 1, "shape": "POINT(0 0)"}]
+
+
+def test_geometry_invalid_wkt_rejected(tmp_path):
+    col = Collection("geo", str(tmp_path / "geo"), _schema())
+
+    with pytest.raises(SchemaValidationError, match="GEOMETRY"):
+        col.insert([{"id": 1, "vec": [0.1, 0.2], "shape": "not-wkt"}])
+
+
+def test_geometry_filter_on_non_geometry_field_rejected(tmp_path):
+    col = Collection("geo", str(tmp_path / "geo"), _schema())
+    col.insert([{"id": 1, "vec": [0.1, 0.2], "shape": "POINT(1 1)"}])
+
+    with pytest.raises(FilterTypeError, match="GEOMETRY field"):
+        col.query("ST_WITHIN(id, 'POLYGON((0 0, 10 0, 10 10, 0 10, 0 0))')")
+
+
+@pytest.mark.parametrize(
+    "expr",
+    [
+        "ST_DWITHIN(shape, 'POINT(1 1)', -1)",
+        "ST_DWITHIN(shape, 'POINT(1 1)')",
+        "ST_DWITHIN(shape, 'POINT(1 1)', 'far')",
+    ],
+)
+def test_geometry_dwithin_invalid_parameters_rejected(tmp_path, expr):
+    col = Collection("geo", str(tmp_path / "geo"), _schema())
+    col.insert([{"id": 1, "vec": [0.1, 0.2], "shape": "POINT(1 1)"}])
+
+    with pytest.raises(Exception):
+        col.query(expr)

--- a/tests/engine/test_geometry.py
+++ b/tests/engine/test_geometry.py
@@ -1,5 +1,6 @@
 import pytest
 
+from milvus_lite.db import MilvusLite
 from milvus_lite.engine.collection import Collection
 from milvus_lite.exceptions import SchemaValidationError
 from milvus_lite.schema.types import CollectionSchema, DataType, FieldSchema
@@ -234,6 +235,30 @@ def test_geometry_invalid_wkt_rejected(tmp_path):
 
     with pytest.raises(SchemaValidationError, match="GEOMETRY"):
         col.insert([{"id": 1, "vec": [0.1, 0.2], "shape": "not-wkt"}])
+
+
+def test_geometry_query_after_db_reopen(tmp_path):
+    data_dir = str(tmp_path / "db")
+    db = MilvusLite(data_dir)
+    col = db.create_collection("geo", _schema())
+    col.insert([
+        {"id": 1, "vec": [0.1, 0.2], "shape": "POINT(1 1)"},
+        {"id": 2, "vec": [0.2, 0.3], "shape": "POINT(20 20)"},
+    ])
+    col.flush()
+    db.close()
+
+    reopened = MilvusLite(data_dir)
+    try:
+        col = reopened.get_collection("geo")
+        rows = col.query(
+            "ST_WITHIN(shape, 'POLYGON((0 0, 10 0, 10 10, 0 10, 0 0))')",
+            output_fields=["shape"],
+        )
+    finally:
+        reopened.close()
+
+    assert rows == [{"id": 1, "shape": "POINT(1 1)"}]
 
 
 def test_geometry_filter_on_non_geometry_field_rejected(tmp_path):

--- a/tests/schema/test_types.py
+++ b/tests/schema/test_types.py
@@ -20,6 +20,7 @@ def test_datatype_values():
     assert DataType.FLOAT_VECTOR.value == "float_vector"
     assert DataType.VARCHAR.value == "varchar"
     assert DataType.JSON.value == "json"
+    assert DataType.GEOMETRY.value == "geometry"
     assert DataType.TIMESTAMPTZ.value == "timestamptz"
 
 
@@ -27,7 +28,7 @@ def test_datatype_members():
     expected = {
         "BOOL", "INT8", "INT16", "INT32", "INT64",
         "FLOAT", "DOUBLE", "VARCHAR", "JSON", "ARRAY",
-        "TIMESTAMPTZ", "FLOAT_VECTOR", "SPARSE_FLOAT_VECTOR",
+        "GEOMETRY", "TIMESTAMPTZ", "FLOAT_VECTOR", "SPARSE_FLOAT_VECTOR",
     }
     assert set(DataType.__members__.keys()) == expected
 
@@ -100,6 +101,7 @@ def test_type_map_scalar_types():
     assert TYPE_MAP[DataType.DOUBLE] == pa.float64()
     assert TYPE_MAP[DataType.VARCHAR] == pa.string()
     assert TYPE_MAP[DataType.JSON] == pa.string()
+    assert TYPE_MAP[DataType.GEOMETRY] == pa.string()
     assert TYPE_MAP[DataType.TIMESTAMPTZ] == pa.timestamp("us", tz="UTC")
 
 

--- a/tests/schema/test_validation.py
+++ b/tests/schema/test_validation.py
@@ -343,6 +343,73 @@ def test_record_field_wrong_type():
         )
 
 
+def test_geometry_record_accepts_wkt():
+    schema = CollectionSchema(fields=[
+        FieldSchema(name="id", dtype=DataType.INT64, is_primary=True),
+        FieldSchema(name="vec", dtype=DataType.FLOAT_VECTOR, dim=2),
+        FieldSchema(name="shape", dtype=DataType.GEOMETRY),
+    ])
+    validate_record({"id": 1, "vec": [0.1, 0.2], "shape": "POINT (1 2)"}, schema)
+
+
+def test_geometry_record_rejects_invalid_wkt():
+    schema = CollectionSchema(fields=[
+        FieldSchema(name="id", dtype=DataType.INT64, is_primary=True),
+        FieldSchema(name="vec", dtype=DataType.FLOAT_VECTOR, dim=2),
+        FieldSchema(name="shape", dtype=DataType.GEOMETRY),
+    ])
+    with pytest.raises(SchemaValidationError, match="GEOMETRY"):
+        validate_record({"id": 1, "vec": [0.1, 0.2], "shape": "not-wkt"}, schema)
+
+
+@pytest.mark.parametrize("bad", ["", "   ", "POINT(nan 1)", "POINT(inf 1)"])
+def test_geometry_record_rejects_empty_or_non_finite_wkt(bad):
+    schema = CollectionSchema(fields=[
+        FieldSchema(name="id", dtype=DataType.INT64, is_primary=True),
+        FieldSchema(name="vec", dtype=DataType.FLOAT_VECTOR, dim=2),
+        FieldSchema(name="shape", dtype=DataType.GEOMETRY),
+    ])
+    with pytest.raises(SchemaValidationError, match="GEOMETRY"):
+        validate_record({"id": 1, "vec": [0.1, 0.2], "shape": bad}, schema)
+
+
+def test_geometry_default_value_fills_missing_record_field():
+    schema = CollectionSchema(fields=[
+        FieldSchema(name="id", dtype=DataType.INT64, is_primary=True),
+        FieldSchema(name="vec", dtype=DataType.FLOAT_VECTOR, dim=2),
+        FieldSchema(name="shape", dtype=DataType.GEOMETRY, default_value="POINT(0 0)"),
+    ])
+    rec = {"id": 1, "vec": [0.1, 0.2]}
+
+    validate_schema(schema)
+    validate_record(rec, schema)
+
+    assert rec["shape"] == "POINT(0 0)"
+
+
+def test_geometry_record_rejects_self_intersecting_polygon():
+    schema = CollectionSchema(fields=[
+        FieldSchema(name="id", dtype=DataType.INT64, is_primary=True),
+        FieldSchema(name="vec", dtype=DataType.FLOAT_VECTOR, dim=2),
+        FieldSchema(name="shape", dtype=DataType.GEOMETRY),
+    ])
+    with pytest.raises(SchemaValidationError, match="GEOMETRY"):
+        validate_record(
+            {"id": 1, "vec": [0.1, 0.2], "shape": "POLYGON((0 0, 2 2, 0 2, 2 0, 0 0))"},
+            schema,
+        )
+
+
+def test_geometry_invalid_default_value_rejected():
+    schema = CollectionSchema(fields=[
+        FieldSchema(name="id", dtype=DataType.INT64, is_primary=True),
+        FieldSchema(name="vec", dtype=DataType.FLOAT_VECTOR, dim=2),
+        FieldSchema(name="shape", dtype=DataType.GEOMETRY, default_value="not-wkt"),
+    ])
+    with pytest.raises(SchemaValidationError, match="default_value"):
+        validate_schema(schema)
+
+
 def test_record_nullable_missing_ok():
     rec = {"id": "doc1", "vec": [0.1, 0.2, 0.3, 0.4], "score": 0.5}  # title missing, nullable
     validate_record(rec, _basic_schema())

--- a/tests/search/filter/test_geometry.py
+++ b/tests/search/filter/test_geometry.py
@@ -7,6 +7,7 @@ from milvus_lite.schema.geometry import (
     geometry_intersects,
     geometry_is_valid,
     geometry_within,
+    validate_geometry_wkt,
 )
 from milvus_lite.schema.types import CollectionSchema, DataType, FieldSchema
 from milvus_lite.search.filter import compile_expr, evaluate, parse_expr
@@ -42,6 +43,15 @@ def test_geometry_helpers_point_polygon():
 )
 def test_geometry_contains_truth_table(left, right, expected):
     assert geometry_contains(left, right) is expected
+
+
+def test_geometry_contains_concave_polygon_rejects_crossing_inner_polygon():
+    outer = "POLYGON((0 0, 4 0, 4 4, 3 4, 3 1, 1 1, 1 4, 0 4, 0 0))"
+    crossing = "POLYGON((0.5 0.5, 3.5 0.5, 3.5 3.5, 0.5 3.5, 0.5 0.5))"
+    contained = "POLYGON((0.2 0.2, 0.8 0.2, 0.8 0.8, 0.2 0.8, 0.2 0.2))"
+
+    assert geometry_contains(outer, crossing) is False
+    assert geometry_contains(outer, contained) is True
 
 
 @pytest.mark.parametrize(
@@ -97,6 +107,21 @@ def test_geometry_is_valid_rejects_non_finite_and_self_intersecting_wkt():
     assert geometry_is_valid("POINT(nan 2)") is False
     assert geometry_is_valid("POINT(inf 2)") is False
     assert geometry_is_valid("POLYGON((0 0, 2 2, 0 2, 2 0, 0 0))") is False
+
+
+@pytest.mark.parametrize(
+    "wkt",
+    [
+        "LINESTRING(0 0, 1 1)",
+        "MULTIPOLYGON(((0 0, 1 0, 1 1, 0 0)))",
+        "POLYGON((0 0, 4 0, 4 4, 0 4, 0 0), (1 1, 2 1, 2 2, 1 1))",
+        "POINT Z (1 2 3)",
+    ],
+)
+def test_geometry_rejects_unsupported_wkt_subset(wkt):
+    assert geometry_is_valid(wkt) is False
+    with pytest.raises(Exception):
+        validate_geometry_wkt(wkt)
 
 
 def test_parse_geometry_predicate():

--- a/tests/search/filter/test_geometry.py
+++ b/tests/search/filter/test_geometry.py
@@ -39,6 +39,16 @@ def test_geometry_helpers_point_polygon():
         ("POLYGON((0 0, 10 0, 10 10, 0 10, 0 0))", "POINT(5 5)", True),
         ("POLYGON((0 0, 10 0, 10 10, 0 10, 0 0))", "POINT(0 5)", True),
         ("POLYGON((0 0, 10 0, 10 10, 0 10, 0 0))", "POINT(15 5)", False),
+        (
+            "POLYGON((0 0, 10 0, 10 10, 0 10, 0 0))",
+            "POLYGON((0 0, 10 0, 10 10, 0 10, 0 0))",
+            True,
+        ),
+        (
+            "POLYGON((0 0, 10 0, 10 10, 0 10, 0 0))",
+            "POLYGON((0 0, 5 0, 5 5, 0 5, 0 0))",
+            True,
+        ),
     ],
 )
 def test_geometry_contains_truth_table(left, right, expected):

--- a/tests/search/filter/test_geometry.py
+++ b/tests/search/filter/test_geometry.py
@@ -1,0 +1,191 @@
+import pytest
+import pyarrow as pa
+
+from milvus_lite.schema.geometry import (
+    geometry_contains,
+    geometry_dwithin,
+    geometry_intersects,
+    geometry_is_valid,
+    geometry_within,
+)
+from milvus_lite.schema.types import CollectionSchema, DataType, FieldSchema
+from milvus_lite.search.filter import compile_expr, evaluate, parse_expr
+from milvus_lite.search.filter.ast import GeometryDWithinOp, GeometryIsValidOp, GeometryOp
+
+
+def _schema():
+    return CollectionSchema(fields=[
+        FieldSchema(name="id", dtype=DataType.INT64, is_primary=True),
+        FieldSchema(name="vec", dtype=DataType.FLOAT_VECTOR, dim=2),
+        FieldSchema(name="shape", dtype=DataType.GEOMETRY),
+    ])
+
+
+def test_geometry_helpers_point_polygon():
+    square = "POLYGON((0 0, 10 0, 10 10, 0 10, 0 0))"
+    assert geometry_contains(square, "POINT(5 5)") is True
+    assert geometry_contains(square, "POINT(15 5)") is False
+    assert geometry_within("POINT(5 5)", square) is True
+    assert geometry_intersects(square, "POINT(0 5)") is True
+
+
+@pytest.mark.parametrize(
+    ("left", "right", "expected"),
+    [
+        ("POINT(1 1)", "POINT(1 1)", True),
+        ("POINT(1 1)", "POINT(2 2)", False),
+        ("POLYGON((0 0, 10 0, 10 10, 0 10, 0 0))", "POINT(5 5)", True),
+        ("POLYGON((0 0, 10 0, 10 10, 0 10, 0 0))", "POINT(0 5)", True),
+        ("POLYGON((0 0, 10 0, 10 10, 0 10, 0 0))", "POINT(15 5)", False),
+    ],
+)
+def test_geometry_contains_truth_table(left, right, expected):
+    assert geometry_contains(left, right) is expected
+
+
+@pytest.mark.parametrize(
+    ("left", "right", "expected"),
+    [
+        ("POINT(5 5)", "POLYGON((0 0, 10 0, 10 10, 0 10, 0 0))", True),
+        ("POINT(0 5)", "POLYGON((0 0, 10 0, 10 10, 0 10, 0 0))", True),
+        ("POINT(15 5)", "POLYGON((0 0, 10 0, 10 10, 0 10, 0 0))", False),
+    ],
+)
+def test_geometry_within_truth_table(left, right, expected):
+    assert geometry_within(left, right) is expected
+
+
+@pytest.mark.parametrize(
+    ("left", "right", "expected"),
+    [
+        ("POINT(1 1)", "POINT(1 1)", True),
+        ("POINT(1 1)", "POINT(2 2)", False),
+        ("POINT(0 5)", "POLYGON((0 0, 10 0, 10 10, 0 10, 0 0))", True),
+        (
+            "POLYGON((0 0, 2 0, 2 2, 0 2, 0 0))",
+            "POLYGON((1 1, 3 1, 3 3, 1 3, 1 1))",
+            True,
+        ),
+        (
+            "POLYGON((0 0, 2 0, 2 2, 0 2, 0 0))",
+            "POLYGON((3 3, 4 3, 4 4, 3 4, 3 3))",
+            False,
+        ),
+    ],
+)
+def test_geometry_intersects_truth_table(left, right, expected):
+    assert geometry_intersects(left, right) is expected
+
+
+@pytest.mark.parametrize(
+    ("left", "right", "distance", "expected"),
+    [
+        ("POINT(1 1)", "POINT(4 5)", 5, True),
+        ("POINT(1 1)", "POINT(4 5)", 4.999, False),
+        ("POINT(1 1)", "POINT(1 1)", 0, True),
+        ("POLYGON((0 0, 2 0, 2 2, 0 2, 0 0))", "POINT(4 1)", 2, True),
+        ("POLYGON((0 0, 2 0, 2 2, 0 2, 0 0))", "POINT(4.1 1)", 2, False),
+    ],
+)
+def test_geometry_dwithin_truth_table(left, right, distance, expected):
+    assert geometry_dwithin(left, right, distance) is expected
+
+
+def test_geometry_is_valid_rejects_non_finite_and_self_intersecting_wkt():
+    assert geometry_is_valid("POINT(1 2)") is True
+    assert geometry_is_valid("POINT(nan 2)") is False
+    assert geometry_is_valid("POINT(inf 2)") is False
+    assert geometry_is_valid("POLYGON((0 0, 2 2, 0 2, 2 0, 0 0))") is False
+
+
+def test_parse_geometry_predicate():
+    expr = parse_expr("geometry_contains(shape, 'POINT(1 2)')")
+    assert isinstance(expr, GeometryOp)
+    assert expr.op == "geometry_contains"
+    assert expr.field.name == "shape"
+    assert expr.geometry.value == "POINT(1 2)"
+
+
+def test_parse_st_geometry_aliases():
+    aliases = {
+        "ST_CONTAINS": "geometry_contains",
+        "ST_WITHIN": "geometry_within",
+        "ST_INTERSECTS": "geometry_intersects",
+    }
+    for alias, op in aliases.items():
+        expr = parse_expr(f"{alias}(shape, 'POINT(1 2)')")
+        assert isinstance(expr, GeometryOp)
+        assert expr.op == op
+        assert expr.field.name == "shape"
+        assert expr.geometry.value == "POINT(1 2)"
+
+
+def test_parse_st_isvalid():
+    expr = parse_expr("ST_ISVALID(shape)")
+    assert isinstance(expr, GeometryIsValidOp)
+    assert expr.field.name == "shape"
+
+
+def test_parse_st_dwithin():
+    expr = parse_expr("ST_DWITHIN(shape, 'POINT(1 2)', 3.5)")
+    assert isinstance(expr, GeometryDWithinOp)
+    assert expr.field.name == "shape"
+    assert expr.geometry.value == "POINT(1 2)"
+    assert expr.distance.value == 3.5
+
+
+def test_geometry_filter_evaluates():
+    schema = _schema()
+    table = pa.table({
+        "id": [1, 2],
+        "vec": [[0.1, 0.2], [0.2, 0.3]],
+        "shape": [
+            "POLYGON((0 0, 10 0, 10 10, 0 10, 0 0))",
+            "POLYGON((20 20, 30 20, 30 30, 20 30, 20 20))",
+        ],
+    })
+    compiled = compile_expr(
+        parse_expr("geometry_contains(shape, 'POINT(5 5)')"),
+        schema,
+        "geometry_contains(shape, 'POINT(5 5)')",
+    )
+
+    result = evaluate(compiled, table)
+
+    assert result.to_pylist() == [True, False]
+
+
+def test_geometry_isvalid_filter_evaluates():
+    schema = _schema()
+    table = pa.table({
+        "id": [1, 2],
+        "vec": [[0.1, 0.2], [0.2, 0.3]],
+        "shape": ["POINT(1 2)", "not-wkt"],
+    })
+    compiled = compile_expr(
+        parse_expr("ST_ISVALID(shape)"),
+        schema,
+        "ST_ISVALID(shape)",
+    )
+
+    result = evaluate(compiled, table)
+
+    assert result.to_pylist() == [True, False]
+
+
+def test_geometry_dwithin_filter_evaluates():
+    schema = _schema()
+    table = pa.table({
+        "id": [1, 2, 3],
+        "vec": [[0.1, 0.2], [0.2, 0.3], [0.3, 0.4]],
+        "shape": ["POINT(1 1)", "POINT(4 5)", "POINT(10 10)"],
+    })
+    compiled = compile_expr(
+        parse_expr("ST_DWITHIN(shape, 'POINT(1 1)', 5)"),
+        schema,
+        "ST_DWITHIN(shape, 'POINT(1 1)', 5)",
+    )
+
+    result = evaluate(compiled, table)
+
+    assert result.to_pylist() == [True, True, False]

--- a/tests/search/filter/test_geometry.py
+++ b/tests/search/filter/test_geometry.py
@@ -10,6 +10,7 @@ from milvus_lite.schema.geometry import (
 )
 from milvus_lite.schema.types import CollectionSchema, DataType, FieldSchema
 from milvus_lite.search.filter import compile_expr, evaluate, parse_expr
+from milvus_lite.search.filter.exceptions import FilterTypeError
 from milvus_lite.search.filter.ast import GeometryDWithinOp, GeometryIsValidOp, GeometryOp
 
 
@@ -132,6 +133,25 @@ def test_parse_st_dwithin():
     assert expr.field.name == "shape"
     assert expr.geometry.value == "POINT(1 2)"
     assert expr.distance.value == 3.5
+
+
+def test_geometry_filter_uses_python_backend():
+    compiled = compile_expr(
+        parse_expr("geometry_contains(shape, 'POINT(5 5)')"),
+        _schema(),
+        "geometry_contains(shape, 'POINT(5 5)')",
+    )
+
+    assert compiled.backend == "python"
+
+
+def test_geometry_filter_rejects_invalid_wkt_literal():
+    with pytest.raises(FilterTypeError, match="valid WKT"):
+        compile_expr(
+            parse_expr("geometry_contains(shape, 'not-wkt')"),
+            _schema(),
+            "geometry_contains(shape, 'not-wkt')",
+        )
 
 
 def test_geometry_filter_evaluates():


### PR DESCRIPTION
Add lightweight WKT geometry storage and spatial filter predicates so Milvus Geometry fields can round-trip through schema, gRPC translation, and query/search filters.