### PR TITLE
feat(index): add scalar inverted index support

### DIFF
--- a/examples/m11_scalar_index_demo.py
+++ b/examples/m11_scalar_index_demo.py
@@ -1,0 +1,128 @@
+"""M11 demo — scalar INVERTED index.
+
+Shows scalar indexes on query() and search() filters:
+
+    insert → flush → create_index(age/category) → query/search with filters
+    → inspect .sidx sidecars → reopen → load → query again
+
+Run:
+    python examples/m11_scalar_index_demo.py
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+
+import numpy as np
+
+from milvus_lite import CollectionSchema, DataType, FieldSchema, MilvusLite
+
+
+def _schema() -> CollectionSchema:
+    return CollectionSchema(fields=[
+        FieldSchema(name="id", dtype=DataType.INT64, is_primary=True),
+        FieldSchema(name="vec", dtype=DataType.FLOAT_VECTOR, dim=4),
+        FieldSchema(name="age", dtype=DataType.INT64, nullable=True),
+        FieldSchema(name="category", dtype=DataType.VARCHAR, nullable=True, max_length=64),
+        FieldSchema(name="active", dtype=DataType.BOOL, nullable=True),
+    ])
+
+
+def _rows() -> list[dict]:
+    categories = ["tech", "news", "blog", "ai", None]
+    rows = []
+    for i in range(20):
+        rows.append({
+            "id": i,
+            "vec": [float(i == j) for j in range(4)],
+            "age": None if i % 9 == 0 else 18 + i,
+            "category": categories[i % len(categories)],
+            "active": None if i % 7 == 0 else i % 2 == 0,
+        })
+    return rows
+
+
+def _ids(rows: list[dict]) -> list[int]:
+    return [int(row["id"]) for row in rows]
+
+
+def _index_files(data_dir: str) -> list[str]:
+    index_dir = os.path.join(data_dir, "collections", "docs", "partitions", "_default", "indexes")
+    if not os.path.isdir(index_dir):
+        return []
+    return sorted(os.listdir(index_dir))
+
+
+def main() -> None:
+    data_dir = tempfile.mkdtemp(prefix="milvus_lite_m11_scalar_index_")
+    print(f"data_dir = {data_dir}")
+
+    try:
+        with MilvusLite(data_dir) as db:
+            col = db.create_collection("docs", _schema())
+            col.insert(_rows())
+            col.flush()
+            print("\n[1] inserted and flushed 20 rows")
+
+            print("\n[2] create scalar INVERTED indexes")
+            col.create_index("age", {"index_type": "INVERTED"})
+            col.create_index("category", {"index_type": "INVERTED"})
+            print(f"   indexes = {col.list_indexes()}")
+            print(f"   age index info = {col.get_index_info('age')}")
+            print(f"   category index info = {col.get_index_info('category')}")
+
+            print("\n[3] query() uses indexed scalar predicates")
+            adults = col.query("age >= 25 and age < 32", output_fields=["age", "category"])
+            print(f"   age >= 25 and age < 32 ids = {_ids(adults)}")
+            assert _ids(adults) == [7, 8, 10, 11, 12, 13]
+
+            tech_or_ai = col.query(
+                "category in ['tech', 'ai']",
+                output_fields=["category"],
+                limit=6,
+            )
+            print(f"   category in ['tech', 'ai'] first ids = {_ids(tech_or_ai)}")
+            assert all(row["category"] in {"tech", "ai"} for row in tech_or_ai)
+
+            print("\n[4] search() combines vector ranking with indexed scalar filter")
+            query = np.asarray([[1, 0, 0, 0]], dtype=np.float32).tolist()
+            results = col.search(
+                query,
+                top_k=5,
+                metric_type="L2",
+                expr="category == 'tech' and age is not null",
+                output_fields=["age", "category"],
+            )
+            for hit in results[0]:
+                entity = hit["entity"]
+                print(
+                    f"   id={hit['id']:2d} dist={hit['distance']:.1f} "
+                    f"age={entity['age']} category={entity['category']}"
+                )
+                assert entity["category"] == "tech"
+                assert entity["age"] is not None
+
+            print("\n[5] .sidx sidecar files were written")
+            sidecars = _index_files(data_dir)
+            for filename in sidecars:
+                print(f"   {filename}")
+            assert any(filename.endswith(".age.inverted.sidx") for filename in sidecars)
+            assert any(filename.endswith(".category.inverted.sidx") for filename in sidecars)
+
+        print("\n[6] reopen collection and load existing scalar index sidecars")
+        with MilvusLite(data_dir) as db:
+            reopened = db.get_collection("docs")
+            reopened.load()
+            rows = reopened.query("category == 'news'", output_fields=["category"])
+            print(f"   category == 'news' ids after reopen = {_ids(rows)}")
+            assert _ids(rows) == [1, 6, 11, 16]
+
+        print("\nOK — M11 demo passed: scalar INVERTED indexes work end-to-end")
+    finally:
+        shutil.rmtree(data_dir, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/milvus_lite/adapter/grpc/servicer.py
+++ b/milvus_lite/adapter/grpc/servicer.py
@@ -493,11 +493,17 @@ class MilvusServicer(milvus_pb2_grpc.MilvusServiceServicer):
             from milvus_lite.function.types import ID_FIELD, SCORE_FIELD
 
             col = self._db.get_collection(request.collection_name)
-            # Pull the canonical metric from the first IndexSpec if any.
-            first_spec = col._index_specs.get(col._vector_name) if col._index_specs else None  # noqa: SLF001
-            if first_spec is None and col._index_specs:
-                first_spec = next(iter(col._index_specs.values()))
-            default_metric = first_spec.metric_type if first_spec else "COSINE"
+            # Pull the canonical metric from a vector index if any.
+            first_spec = (
+                col._index_specs.get(col._vector_name)  # noqa: SLF001
+                if col._index_specs and col._vector_name is not None  # noqa: SLF001
+                else None
+            )
+            default_metric = (
+                first_spec.metric_type
+                if first_spec is not None and first_spec.metric_type != "NONE"
+                else "COSINE"
+            )
             parsed = parse_search_request(request, default_metric_type=default_metric)
 
             group_by_field = parsed.get("group_by_field")
@@ -645,9 +651,7 @@ class MilvusServicer(milvus_pb2_grpc.MilvusServiceServicer):
         """
         try:
             col = self._db.get_collection(request.collection_name)
-            params = kv_pairs_to_index_params_dict(
-                request.extra_params, field_name=request.field_name
-            )
+            params = kv_pairs_to_index_params_dict(request.extra_params)
             col.create_index(request.field_name, params)
             return common_pb2.Status(**success_status_kwargs())
         except MilvusLiteError as e:

--- a/milvus_lite/adapter/grpc/translators/index.py
+++ b/milvus_lite/adapter/grpc/translators/index.py
@@ -28,39 +28,27 @@ from milvus_lite.exceptions import SchemaValidationError
 from milvus_lite.index.spec import IndexSpec
 
 
-def kv_pairs_to_index_params_dict(
-    extra_params: Iterable,
-    field_name: str = "",
-) -> dict:
+def kv_pairs_to_index_params_dict(extra_params: Iterable) -> dict:
     """Decode the CreateIndexRequest.extra_params KeyValuePair list
     into a dict suitable for ``Collection.create_index(field, params)``.
 
     Args:
         extra_params: iterable of common_pb2.KeyValuePair messages
-        field_name: fallback field_name from the outer request, used
-            if the KV list doesn't carry one
 
     Returns:
         ``{"index_type": ..., "metric_type": ..., "params": {...},
-            "search_params": {...}}``  — the shape Collection.create_index
-        consumes.
+            "search_params": {...}}``  — the index_params shape
+        Collection.create_index consumes.
 
     Raises:
-        SchemaValidationError: required keys (index_type, metric_type)
-            missing or malformed
+        SchemaValidationError: required keys are missing or malformed
     """
     kv: dict[str, str] = {p.key: p.value for p in extra_params}
 
     index_type = kv.get("index_type")
-    metric_type = kv.get("metric_type")
-
     if not index_type:
         raise SchemaValidationError(
             "create_index missing required 'index_type' parameter"
-        )
-    if not metric_type:
-        raise SchemaValidationError(
-            "create_index missing required 'metric_type' parameter"
         )
 
     # `params` is a JSON-encoded string in the wire format. pymilvus
@@ -87,12 +75,14 @@ def kv_pairs_to_index_params_dict(
     else:
         search_params = {}
 
-    return {
+    out = {
         "index_type": index_type,
-        "metric_type": metric_type,
         "params": build_params,
         "search_params": search_params,
     }
+    if "metric_type" in kv:
+        out["metric_type"] = kv["metric_type"]
+    return out
 
 
 def index_spec_to_kv_pairs(spec: IndexSpec) -> List:

--- a/milvus_lite/engine/collection.py
+++ b/milvus_lite/engine/collection.py
@@ -56,6 +56,14 @@ from milvus_lite.exceptions import (
     SchemaValidationError,
 )
 from milvus_lite.index.brute_force import BruteForceIndex
+from milvus_lite.index.factory import KNOWN_VECTOR_INDEX_TYPES
+from milvus_lite.index.files import index_sidecar_suffix, parse_index_sidecar_name
+from milvus_lite.index.scalar import (
+    IMPLEMENTED_SCALAR_INDEX_TYPES,
+    KNOWN_SCALAR_INDEX_TYPES,
+    SUPPORTED_DTYPES_BY_SCALAR_INDEX_TYPE,
+    plan_indexed_filter,
+)
 from milvus_lite.index.spec import IndexSpec
 from milvus_lite.schema.types import DataType, FunctionType
 from milvus_lite.schema.arrow_builder import (
@@ -87,6 +95,47 @@ if False:  # TYPE_CHECKING
 # Segment cache key: (partition, relative_path) — relative_path is what
 # the manifest stores so two segments cannot collide on the same name.
 _SegmentKey = Tuple[str, str]
+
+
+def _validate_scalar_index_request(dtype: DataType, index_type: str) -> None:
+    if index_type not in KNOWN_SCALAR_INDEX_TYPES:
+        raise SchemaValidationError(
+            f"unknown scalar index_type {index_type!r}; supported scalar index_type: INVERTED"
+        )
+    if index_type not in IMPLEMENTED_SCALAR_INDEX_TYPES:
+        raise SchemaValidationError(
+            f"scalar index_type {index_type!r} is not implemented; supported: INVERTED"
+        )
+    if dtype not in SUPPORTED_DTYPES_BY_SCALAR_INDEX_TYPE[index_type]:
+        raise SchemaValidationError(
+            f"field type {dtype.name} does not support scalar index"
+        )
+
+
+def _is_scalar_index_spec(spec: Optional[IndexSpec]) -> bool:
+    return spec is not None and spec.index_type in IMPLEMENTED_SCALAR_INDEX_TYPES
+
+
+def _index_file_suffix(spec: IndexSpec) -> str:
+    return index_sidecar_suffix(
+        spec.field_name, spec.index_type, scalar=_is_scalar_index_spec(spec),
+    )
+
+
+def _schema_field(
+    schema: CollectionSchema,
+    field_name: str,
+    *,
+    error_message: Optional[str] = None,
+):
+    field = next((f for f in schema.fields if f.name == field_name), None)
+    if field is None:
+        raise SchemaValidationError(error_message or f"unknown field {field_name!r}")
+    return field
+
+
+def _field_dtype(schema: CollectionSchema, field_name: str) -> DataType:
+    return _schema_field(schema, field_name).dtype
 
 
 def _row_matches_filter(record: dict, compiled_filter) -> bool:
@@ -644,11 +693,11 @@ class Collection:
 
         # Validate group_by_field
         if group_by_field is not None:
-            gf = next((f for f in self._schema.fields if f.name == group_by_field), None)
-            if gf is None:
-                raise SchemaValidationError(
-                    f"group_by_field {group_by_field!r} not found in schema"
-                )
+            gf = _schema_field(
+                self._schema,
+                group_by_field,
+                error_message=f"group_by_field {group_by_field!r} not found in schema",
+            )
             _GROUP_BY_ALLOWED = (
                 DataType.INT8, DataType.INT16, DataType.INT32, DataType.INT64,
                 DataType.BOOL, DataType.VARCHAR,
@@ -709,6 +758,7 @@ class Collection:
                     f"query_vectors must be a 2-D list, got shape {q_arr.shape}"
                 )
             compiled_filter = self._compile_filter(expr, timezone=timezone) if expr else None
+            indexed_filter_plan = self._indexed_filter_plan(compiled_filter)
             seg_snap, delta_snap = self._read_snapshot()
             raw_results = execute_search_with_index(
                 query_vectors=q_arr,
@@ -722,6 +772,7 @@ class Collection:
                 partition_names=partition_names,
                 compiled_filter=compiled_filter,
                 output_fields=output_fields,
+                indexed_filter_plan=indexed_filter_plan,
             )
 
         # Apply range filter (before group_by)
@@ -780,11 +831,11 @@ class Collection:
                 )
             return self._vector_name
 
-        field = next((f for f in self._schema.fields if f.name == anns_field), None)
-        if field is None:
-            raise SchemaValidationError(
-                f"anns_field {anns_field!r} not found in schema"
-            )
+        field = _schema_field(
+            self._schema,
+            anns_field,
+            error_message=f"anns_field {anns_field!r} not found in schema",
+        )
         if field.dtype not in (DataType.FLOAT_VECTOR, DataType.SPARSE_FLOAT_VECTOR):
             raise SchemaValidationError(
                 f"anns_field {anns_field!r} is not a vector field "
@@ -836,6 +887,8 @@ class Collection:
         # Convert query vectors upfront
         query_sparse = self._prepare_sparse_queries(query_vectors)
         nq = len(query_sparse)
+        compiled_filter = self._compile_filter(expr, timezone=timezone) if expr else None
+        indexed_filter_plan = self._indexed_filter_plan(compiled_filter)
 
         # Per-source candidates: (distance, global_pk, source_ref)
         Candidate = Tuple[float, Any, Any]  # (dist, pk, (tbl, row_idx))
@@ -895,11 +948,11 @@ class Collection:
                     valid_mask[i] = False
 
             # Apply scalar filter
-            if expr:
-                compiled = self._compile_filter(expr, timezone=timezone)
-                from milvus_lite.search.filter.eval import evaluate as filter_evaluate
-                fmask = filter_evaluate(compiled, table).to_numpy(zero_copy_only=False)
-                valid_mask = valid_mask & fmask
+            if compiled_filter is not None:
+                from milvus_lite.search.indexed_filter import evaluate_segment_filter
+                valid_mask = valid_mask & evaluate_segment_filter(
+                    seg, compiled_filter, indexed_filter_plan,
+                )
 
             if not valid_mask.any():
                 continue
@@ -933,13 +986,12 @@ class Collection:
         if mt_pks:
             mt_valid = np.ones(len(mt_pks), dtype=bool)
 
-            if expr:
-                compiled = self._compile_filter(expr, timezone=timezone)
+            if compiled_filter is not None:
                 from milvus_lite.search.filter.eval.python_backend import _eval_row
                 for i in range(len(mt_pks)):
                     if mt_valid[i]:
                         record, _seq = mt_refs[i]
-                        if not _eval_row(compiled.ast, record):
+                        if not _eval_row(compiled_filter.ast, record):
                             mt_valid[i] = False
 
             mt_idx = SparseInvertedIndex(k1=bm25_k1, b=bm25_b)
@@ -1097,6 +1149,7 @@ class Collection:
         self._require_loaded()
 
         compiled_filter = self._compile_filter(expr, timezone=timezone) if expr else None
+        indexed_filter_plan = self._indexed_filter_plan(compiled_filter)
 
         seg_snap, delta_snap = self._read_snapshot()
 
@@ -1106,6 +1159,7 @@ class Collection:
             vector_field=self._vector_name,
             partition_names=partition_names,
             filter_compiled=compiled_filter,
+            indexed_filter_plan=indexed_filter_plan,
         )
 
         if not all_pks:
@@ -1138,7 +1192,7 @@ class Collection:
         Layout: ``data_dir/partitions/<partition>/indexes/``
 
         The directory is created on demand by build_or_load_index when
-        the first .idx is written.
+        the first index sidecar is written.
         """
         return os.path.join(self._data_dir, "partitions", partition, "indexes")
 
@@ -1179,6 +1233,28 @@ class Collection:
         )
         self._filter_cache.put(cache_key, compiled)
         return compiled
+
+    def _indexed_filter_plan(self, compiled_filter):
+        if compiled_filter is None:
+            return None
+        indexed_fields = {
+            field_name for field_name in compiled_filter.fields
+            if _is_scalar_index_spec(self._index_specs.get(field_name))
+        }
+        if not indexed_fields:
+            return None
+        return plan_indexed_filter(compiled_filter, indexed_fields)
+
+    def _build_or_load_segment_index(self, seg: Segment, spec: IndexSpec) -> None:
+        index_dir = self._index_dir(seg.partition)
+        if _is_scalar_index_spec(spec):
+            seg.build_or_load_scalar_index(
+                spec,
+                index_dir,
+                _field_dtype(self._schema, spec.field_name),
+            )
+        else:
+            seg.build_or_load_index(spec, index_dir)
 
     def _effective_timezone(self, timezone: Optional[str] = None) -> Optional[str]:
         if timezone is not None and timezone != "":
@@ -1361,23 +1437,34 @@ class Collection:
                     f"call drop_index first"
                 )
 
-            # Validate the field is in the schema and is a vector type.
-            target = next((f for f in self._schema.fields if f.name == field_name), None)
-            if target is None:
-                raise SchemaValidationError(
-                    f"unknown field {field_name!r} for create_index"
-                )
-            if target.dtype not in (DataType.FLOAT_VECTOR, DataType.SPARSE_FLOAT_VECTOR):
-                raise SchemaValidationError(
-                    f"field {field_name!r} has type {target.dtype.name}; "
-                    f"create_index only supports vector fields"
-                )
+            target = _schema_field(
+                self._schema,
+                field_name,
+                error_message=f"unknown field {field_name!r} for create_index",
+            )
+
+            index_type = str(index_params["index_type"]).upper()
+            build_params = dict(index_params.get("params") or {})
+            metric_type = index_params.get("metric_type")
+            if target.dtype in (DataType.FLOAT_VECTOR, DataType.SPARSE_FLOAT_VECTOR):
+                if metric_type is None:
+                    raise SchemaValidationError(
+                        "create_index missing required 'metric_type' parameter"
+                    )
+            else:
+                if index_type in KNOWN_VECTOR_INDEX_TYPES:
+                    raise SchemaValidationError(
+                        f"field {field_name!r} has type {target.dtype.name}; "
+                        f"create_index with index_type {index_type!r} requires a vector field"
+                    )
+                _validate_scalar_index_request(target.dtype, index_type)
+                metric_type = metric_type or "NONE"
 
             spec = IndexSpec(
                 field_name=field_name,
-                index_type=index_params["index_type"],
-                metric_type=index_params["metric_type"],
-                build_params=dict(index_params.get("params") or {}),
+                index_type=index_type,
+                metric_type=metric_type,
+                build_params=build_params,
                 search_params=dict(index_params.get("search_params") or {}),
             )
 
@@ -1391,11 +1478,11 @@ class Collection:
             if self._load_state == "loaded":
                 for seg in self._segment_cache.values():
                     if seg.num_rows > 0:
-                        seg.build_or_load_index(spec, self._index_dir(seg.partition))
+                        self._build_or_load_segment_index(seg, spec)
 
     def drop_index(self, field_name: Optional[str] = None) -> None:
         """Remove the IndexSpec, release in-memory indexes, and delete
-        on-disk .idx files.
+        on-disk index sidecars.
 
         Args:
             field_name: optional; if given, must match the existing
@@ -1406,7 +1493,7 @@ class Collection:
             IndexNotFoundError: no index has been created
 
         Phase 9.4: also walks every partition's ``indexes/`` directory
-        and deletes the .idx files matching the dropped index_type.
+        and deletes the index sidecars matching the dropped index_type.
         Other index_type files (if any — currently impossible since we
         only support one index per Collection) are left alone.
         """
@@ -1422,7 +1509,7 @@ class Collection:
             # is loaded. Caller must release() first.
             if self._load_state == "loaded":
                 raise SchemaValidationError(
-                    "vector index cannot be dropped on loaded collection; "
+                    "index cannot be dropped on loaded collection; "
                     "call release() first"
                 )
 
@@ -1438,7 +1525,7 @@ class Collection:
                 )
             if self._load_state == "loaded":
                 raise SchemaValidationError(
-                    "vector index cannot be dropped on loaded collection; "
+                    "index cannot be dropped on loaded collection; "
                     "call release() first"
                 )
 
@@ -1453,13 +1540,13 @@ class Collection:
                 for seg in self._segment_cache.values():
                     seg.release_index(field_name=spec.field_name)
 
-            # Delete on-disk .idx files matching the dropped (field, type)
+            # Delete on-disk sidecars matching the dropped (field, type)
             # pair, unless a snapshot still references them.
             _snapshot_data_refs, _snapshot_delta_refs, snapshot_index_refs = snapshot_references(
                 self._data_dir
             )
             for spec in drop_specs:
-                suffix = f".{spec.field_name}.{spec.index_type.lower()}.idx"
+                suffix = _index_file_suffix(spec)
                 for partition in self._manifest.list_partitions():
                     index_dir = self._index_dir(partition)
                     if not os.path.exists(index_dir):
@@ -1513,7 +1600,7 @@ class Collection:
         segment if an IndexSpec exists; idempotent if already loaded.
 
         Phase 9.4: indexes are persisted to disk. The first load() after
-        a fresh create_index builds them and writes .idx sidecars; every
+        a fresh create_index builds them and writes index sidecars; every
         subsequent load() (including after process restart) reads them
         back via Segment.build_or_load_index, so cold-start is fast.
 
@@ -1532,9 +1619,7 @@ class Collection:
                     for seg in self._segment_cache.values():
                         if seg.num_rows == 0:
                             continue
-                        seg.build_or_load_index(
-                            spec, self._index_dir(seg.partition)
-                        )
+                        self._build_or_load_segment_index(seg, spec)
                 self._load_state = "loaded"
             except Exception:
                 self._load_state = "released"
@@ -1799,7 +1884,7 @@ class Collection:
                 self._cleanup_orphan_index_files()
 
             # Phase B: index build — outside the lock. build_or_load_index
-            # operates on an immutable Segment and writes a dedicated .idx
+            # operates on an immutable Segment and writes a dedicated sidecar
             # file, so concurrent user-thread flushes are safe.
             import time as _time
             t0 = _time.monotonic()
@@ -1837,20 +1922,25 @@ class Collection:
         built = 0
         for spec in specs:
             for seg in segs:
-                if spec.field_name not in seg.indexes and seg.num_rows > 0:
-                    seg.build_or_load_index(
-                        spec, self._index_dir(seg.partition)
-                    )
+                if seg.num_rows == 0:
+                    continue
+                has_index = (
+                    spec.field_name in seg.scalar_indexes
+                    if _is_scalar_index_spec(spec)
+                    else spec.field_name in seg.indexes
+                )
+                if not has_index:
+                    self._build_or_load_segment_index(seg, spec)
                     built += 1
         return built
 
     def _cleanup_orphan_index_files(self) -> None:
-        """Phase 9.4: delete .idx files whose source segment is gone.
+        """Delete index sidecars whose source segment is gone.
 
         Called from _trigger_flush after _refresh_segment_cache (which
         evicts compaction-removed segments). The cleanup compares the
         on-disk indexes/ directories against the manifest's data file
-        list and removes any .idx whose stem doesn't match a current
+        list and removes any sidecar whose stem doesn't match a current
         data file.
 
         This is the architectural safety net for invariant §11
@@ -1859,7 +1949,7 @@ class Collection:
         if not self._index_specs:
             return
 
-        # File format: <data_stem>.<field>.<index_type>.idx
+        # File format: <data_stem>.<field>.<index_type>.idx/.sidx
         # Build {field → index_type_lower} so we can validate both parts.
         expected: Dict[str, str] = {
             spec.field_name: spec.index_type.lower()
@@ -1877,20 +1967,15 @@ class Collection:
                 os.path.splitext(os.path.basename(df))[0] for df in data_files
             }
             for entry in os.listdir(index_dir):
-                if not entry.endswith(".idx"):
+                sidecar = parse_index_sidecar_name(entry)
+                if sidecar is None:
                     continue
-                base = entry[: -len(".idx")]
-                stem_field, _, idx_type = base.rpartition(".")
-                stem, _, field = stem_field.rpartition(".")
-                # Drop if (a) source data gone, or (b) field/type no
-                # longer in the active index_specs (dropped index).
                 rel = os.path.join("indexes", entry)
                 if rel in pinned_indexes:
                     continue
                 if (
-                    not stem
-                    or stem not in valid_stems
-                    or expected.get(field) != idx_type
+                    sidecar.source_stem not in valid_stems
+                    or expected.get(sidecar.field_name) != sidecar.index_type
                 ):
                     try:
                         os.remove(os.path.join(index_dir, entry))

--- a/milvus_lite/engine/recovery.py
+++ b/milvus_lite/engine/recovery.py
@@ -24,6 +24,7 @@ import os
 from typing import TYPE_CHECKING, Iterator, List, Tuple
 
 from milvus_lite.engine.operation import DeleteOp, InsertOp, Operation
+from milvus_lite.index.files import parse_index_sidecar_name
 from milvus_lite.storage.delta_index import DeltaIndex
 from milvus_lite.storage.memtable import MemTable
 from milvus_lite.storage.snapshots import snapshot_references
@@ -175,7 +176,7 @@ def _cleanup_orphan_files(data_dir: str, manifest: "Manifest") -> None:
 
     Walks every partition's data/ and delta/ subdirectories.
 
-    Phase 9.4: also walks ``indexes/`` and removes any .idx whose
+    Also walks ``indexes/`` and removes any index sidecar whose
     source data file (matched by filename stem) is no longer in the
     manifest. This handles the case where a crash happens after
     compaction wrote new segments but before the old indexes were
@@ -200,7 +201,7 @@ def _cleanup_orphan_files(data_dir: str, manifest: "Manifest") -> None:
         referenced_delta.setdefault(partition, set()).update(files)
     # For index orphan detection we need the bare stems (without the
     # "data/" prefix and ".parquet" suffix) so we can compare against
-    # .idx file stems.
+    # index sidecar source stems.
     referenced_data_stems: dict[str, set[str]] = {}
     for p, files in referenced_data.items():
         stems: set[str] = set()
@@ -250,24 +251,11 @@ def _cleanup_orphan_files(data_dir: str, manifest: "Manifest") -> None:
         if os.path.isdir(index_subdir):
             valid_stems = referenced_data_stems.get(partition, set())
             for fn in os.listdir(index_subdir):
-                # Index filename convention:
-                #   <data_stem>.<field_name>.<index_type_lower>.idx
-                # Strip .idx, then rpartition twice to peel off index_type
-                # and field_name, leaving the data_stem.
-                # E.g. "data_000001_000050.dense.hnsw.idx"
-                #  → base = "data_000001_000050.dense.hnsw"
-                #  → after first rpartition: ("data_000001_000050.dense", "hnsw")
-                #  → after second rpartition: ("data_000001_000050", "dense")
-                if not fn.endswith(".idx"):
+                sidecar = parse_index_sidecar_name(fn)
+                if sidecar is None:
                     continue
-                base = fn[:-len(".idx")]
-                stem_field, _, _index_type = base.rpartition(".")
-                stem, _, _field_name = stem_field.rpartition(".")
-                if not stem:
-                    # Malformed name; remove defensively.
-                    stem = stem_field or base
                 rel = os.path.join("indexes", fn)
-                if stem not in valid_stems and rel not in referenced_index.get(partition, set()):
+                if sidecar.source_stem not in valid_stems and rel not in referenced_index.get(partition, set()):
                     abs_path = os.path.join(index_subdir, fn)
                     try:
                         os.remove(abs_path)

--- a/milvus_lite/index/__init__.py
+++ b/milvus_lite/index/__init__.py
@@ -1,6 +1,6 @@
 """Vector index subsystem (Phase 9).
 
-Each VectorIndex is bound 1:1 to a Segment (one .idx sidecar per data
+Each VectorIndex is bound 1:1 to a Segment (one index sidecar per data
 Parquet file). Indexes are immutable — compaction creates a new merged
 segment + a new index, dropping the old ones.
 

--- a/milvus_lite/index/brute_force.py
+++ b/milvus_lite/index/brute_force.py
@@ -144,8 +144,7 @@ class BruteForceIndex(VectorIndex):
 
         Uses an explicit file handle (np.save would otherwise auto-
         append .npy if the path lacks that extension, which would break
-        Phase 9.4's strict ``<segment_stem>.<index_type>.idx`` naming
-        convention).
+        index sidecar naming).
 
         The NPY header carries dtype + shape so the load path doesn't
         need explicit dim/metric — only metric is supplied externally
@@ -159,8 +158,8 @@ class BruteForceIndex(VectorIndex):
         """Reload a previously saved BruteForceIndex.
 
         *dim* is validated against the on-disk shape; mismatch is a
-        loud error (not a silent reshape) since it indicates the .idx
-        file is paired with the wrong segment.
+        loud error (not a silent reshape) since it indicates the index
+        sidecar is paired with the wrong segment.
         """
         with open(path, "rb") as f:
             vectors = np.load(f, allow_pickle=False)

--- a/milvus_lite/index/factory.py
+++ b/milvus_lite/index/factory.py
@@ -50,6 +50,12 @@ _FAISS_INDEX_TYPES = frozenset({
     "HNSW", "HNSW_SQ",
     "IVF_FLAT", "IVF_SQ8", "IVF_PQ",
 })
+KNOWN_VECTOR_INDEX_TYPES = frozenset({
+    "AUTOINDEX",
+    "BRUTE_FORCE",
+    "FLAT",
+    "SPARSE_INVERTED_INDEX",
+}) | _FAISS_INDEX_TYPES
 
 
 def is_faiss_available() -> bool:

--- a/milvus_lite/index/files.py
+++ b/milvus_lite/index/files.py
@@ -1,0 +1,52 @@
+"""Helpers for index sidecar filenames."""
+
+from __future__ import annotations
+
+import os
+from typing import NamedTuple, Optional
+
+
+VECTOR_INDEX_FILE_EXT = ".idx"
+SCALAR_INDEX_FILE_EXT = ".sidx"
+INDEX_FILE_EXTENSIONS = (VECTOR_INDEX_FILE_EXT, SCALAR_INDEX_FILE_EXT)
+
+
+class IndexSidecarName(NamedTuple):
+    source_stem: str
+    field_name: str
+    index_type: str
+    extension: str
+
+
+def index_sidecar_suffix(field_name: str, index_type: str, *, scalar: bool) -> str:
+    ext = SCALAR_INDEX_FILE_EXT if scalar else VECTOR_INDEX_FILE_EXT
+    return f".{field_name}.{index_type.lower()}{ext}"
+
+
+def index_sidecar_path(
+    index_dir: str,
+    source_file_path: str,
+    field_name: str,
+    index_type: str,
+    *,
+    scalar: bool,
+) -> str:
+    source_stem = os.path.splitext(os.path.basename(source_file_path))[0]
+    return os.path.join(
+        index_dir,
+        f"{source_stem}{index_sidecar_suffix(field_name, index_type, scalar=scalar)}",
+    )
+
+
+def parse_index_sidecar_name(filename: str) -> Optional[IndexSidecarName]:
+    ext = next((suffix for suffix in INDEX_FILE_EXTENSIONS if filename.endswith(suffix)), None)
+    if ext is None:
+        return None
+    base = filename[: -len(ext)]
+    stem_field, sep, index_type = base.rpartition(".")
+    if not sep or not index_type:
+        return None
+    source_stem, sep, field_name = stem_field.rpartition(".")
+    if not sep or not source_stem or not field_name:
+        return None
+    return IndexSidecarName(source_stem, field_name, index_type, ext)

--- a/milvus_lite/index/protocol.py
+++ b/milvus_lite/index/protocol.py
@@ -1,7 +1,7 @@
 """VectorIndex protocol — abstract per-segment vector index.
 
 A VectorIndex is the unit of vector retrieval in Phase 9. It is bound
-1:1 to a Segment (each immutable data Parquet file gets one .idx
+1:1 to a Segment (each immutable data Parquet file gets one index
 sidecar). Indexes are immutable: there is no add() or remove() — any
 mutation goes through "drop old segment + build new segment + build
 new index", driven by compaction.
@@ -103,9 +103,8 @@ class VectorIndex(ABC):
     def save(self, path: str) -> None:
         """Persist the index to *path*. Format is implementation-defined.
 
-        The caller is responsible for choosing the path (typically
-        ``indexes/<segment_stem>.<index_type>.idx``). The index file
-        becomes a sidecar of its source data Parquet — see Phase 9.4.
+        The caller is responsible for choosing the path. The index file
+        becomes a sidecar of its source data Parquet.
         """
 
     @classmethod
@@ -125,6 +124,6 @@ class VectorIndex(ABC):
     def index_type(self) -> str:
         """A short string tag like 'BRUTE_FORCE' / 'HNSW' / 'IVF_FLAT'.
 
-        Used in .idx filenames and in describe_index responses.
+        Used in index sidecar filenames and in describe_index responses.
         Conventionally uppercase to match Milvus's index_type strings.
         """

--- a/milvus_lite/index/scalar/__init__.py
+++ b/milvus_lite/index/scalar/__init__.py
@@ -1,0 +1,21 @@
+"""Scalar index implementations."""
+
+from milvus_lite.index.scalar.capabilities import (
+    IMPLEMENTED_SCALAR_INDEX_TYPES,
+    KNOWN_SCALAR_INDEX_TYPES,
+    SUPPORTED_DTYPES_BY_SCALAR_INDEX_TYPE,
+    SUPPORTED_SCALAR_INDEX_DTYPES,
+)
+from milvus_lite.index.scalar.inverted import ScalarInvertedIndex
+from milvus_lite.index.scalar.planner import IndexedFilterPlan, ScalarPredicate, plan_indexed_filter
+
+__all__ = [
+    "IMPLEMENTED_SCALAR_INDEX_TYPES",
+    "KNOWN_SCALAR_INDEX_TYPES",
+    "SUPPORTED_DTYPES_BY_SCALAR_INDEX_TYPE",
+    "SUPPORTED_SCALAR_INDEX_DTYPES",
+    "ScalarInvertedIndex",
+    "ScalarPredicate",
+    "IndexedFilterPlan",
+    "plan_indexed_filter",
+]

--- a/milvus_lite/index/scalar/capabilities.py
+++ b/milvus_lite/index/scalar/capabilities.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from milvus_lite.schema.types import DataType
+
+
+IMPLEMENTED_SCALAR_INDEX_TYPES = frozenset({"INVERTED"})
+KNOWN_SCALAR_INDEX_TYPES = frozenset({"INVERTED", "BITMAP", "STL_SORT", "TRIE", "NGRAM"})
+SUPPORTED_SCALAR_INDEX_DTYPES = frozenset({
+    DataType.BOOL,
+    DataType.INT8,
+    DataType.INT16,
+    DataType.INT32,
+    DataType.INT64,
+    DataType.FLOAT,
+    DataType.DOUBLE,
+    DataType.VARCHAR,
+    DataType.TIMESTAMPTZ,
+})
+SUPPORTED_DTYPES_BY_SCALAR_INDEX_TYPE = {
+    "INVERTED": SUPPORTED_SCALAR_INDEX_DTYPES,
+}

--- a/milvus_lite/index/scalar/inverted.py
+++ b/milvus_lite/index/scalar/inverted.py
@@ -1,0 +1,214 @@
+"""Segment-level scalar INVERTED index."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List
+
+import numpy as np
+import pyarrow as pa
+import pyarrow.ipc as ipc
+
+from milvus_lite.index.scalar.capabilities import SUPPORTED_SCALAR_INDEX_DTYPES
+from milvus_lite.index.scalar.planner import ScalarPredicate
+from milvus_lite.schema.timestamptz import parse_timestamptz
+from milvus_lite.schema.types import DataType
+
+
+_SCALAR_INDEX_VERSION = "1"
+
+
+@dataclass
+class ScalarInvertedIndex:
+    field_name: str
+    dtype: DataType
+    row_count: int
+    null_mask: np.ndarray
+    value_to_rows: Dict[Any, np.ndarray]
+    sorted_values: np.ndarray
+    sorted_rows: np.ndarray
+
+    @classmethod
+    def build(cls, table: pa.Table, field_name: str, dtype: DataType) -> "ScalarInvertedIndex":
+        if dtype not in SUPPORTED_SCALAR_INDEX_DTYPES:
+            raise NotImplementedError(
+                f"scalar index INVERTED does not support field type {dtype.name}"
+            )
+        normalized = [
+            _normalize_value(value, dtype)
+            for value in table.column(field_name).to_pylist()
+        ]
+        return cls._from_normalized_values(field_name, dtype, normalized)
+
+    @classmethod
+    def load(cls, path: str) -> "ScalarInvertedIndex":
+        with pa.memory_map(path, "r") as source:
+            reader = ipc.RecordBatchFileReader(source)
+            metadata = reader.schema.metadata or {}
+            if metadata.get(b"milvus_lite.scalar_index.version") != _SCALAR_INDEX_VERSION.encode():
+                raise ValueError(f"unsupported scalar index file version at {path!r}")
+            field_name = metadata[b"field_name"].decode()
+            dtype = DataType[metadata[b"dtype"].decode()]
+            row_count = int(metadata[b"row_count"].decode())
+            table = reader.read_all()
+
+        values = table.column("value").to_pylist()
+        row_ids = table.column("row_id").to_numpy(zero_copy_only=False)
+        is_null = table.column("is_null").to_numpy(zero_copy_only=False)
+
+        normalized: List[Any] = [None] * row_count
+        for value, row_id, null_flag in zip(values, row_ids, is_null):
+            if not null_flag:
+                normalized[int(row_id)] = _normalize_value(value, dtype)
+
+        return cls._from_normalized_values(field_name, dtype, normalized)
+
+    @classmethod
+    def _from_normalized_values(
+        cls,
+        field_name: str,
+        dtype: DataType,
+        normalized: List[Any],
+    ) -> "ScalarInvertedIndex":
+        row_count = len(normalized)
+        null_mask = np.asarray([value is None for value in normalized], dtype=bool)
+        buckets: Dict[Any, List[int]] = {}
+        sorted_pairs: List[tuple[Any, int]] = []
+        for row_id, value in enumerate(normalized):
+            if value is None:
+                continue
+            buckets.setdefault(value, []).append(row_id)
+            sorted_pairs.append((value, row_id))
+
+        value_to_rows = {
+            value: np.asarray(rows, dtype=np.int64)
+            for value, rows in buckets.items()
+        }
+        sorted_pairs.sort(key=lambda item: item[0])
+        sorted_values = np.asarray([p[0] for p in sorted_pairs], dtype=_numpy_dtype(dtype))
+        sorted_rows = np.asarray([p[1] for p in sorted_pairs], dtype=np.int64)
+        return cls(field_name, dtype, row_count, null_mask, value_to_rows, sorted_values, sorted_rows)
+
+    def save(self, path: str) -> None:
+        null_rows = np.flatnonzero(self.null_mask).astype(np.int64, copy=False)
+        values = self.sorted_values.tolist() + [None] * int(null_rows.size)
+        row_ids = self.sorted_rows.astype(np.int64, copy=False).tolist() + null_rows.tolist()
+        is_null = [False] * int(self.sorted_rows.size) + [True] * int(null_rows.size)
+
+        table = pa.Table.from_arrays(
+            [
+                pa.array(values, type=_arrow_type(self.dtype)),
+                pa.array(row_ids, type=pa.int64()),
+                pa.array(is_null, type=pa.bool_()),
+            ],
+            names=["value", "row_id", "is_null"],
+        )
+        metadata = {
+            b"milvus_lite.scalar_index.version": _SCALAR_INDEX_VERSION.encode(),
+            b"field_name": self.field_name.encode(),
+            b"dtype": self.dtype.name.encode(),
+            b"row_count": str(self.row_count).encode(),
+        }
+        table = table.replace_schema_metadata(metadata)
+        with pa.OSFile(path, "wb") as sink:
+            with ipc.RecordBatchFileWriter(sink, table.schema) as writer:
+                writer.write_table(table)
+
+    def match(self, predicate: ScalarPredicate) -> np.ndarray:
+        op = predicate.op
+        if op == "==":
+            return self._eq(predicate.value)
+        if op == "!=":
+            return (~self._eq(predicate.value)) & (~self.null_mask)
+        if op == "in":
+            return self._in(predicate.values)
+        if op == "not in":
+            return ~self._in(predicate.values)
+        if op in ("<", "<=", ">", ">="):
+            return self._range(op, predicate.value)
+        if op == "is null":
+            return self.null_mask.copy()
+        if op == "is not null":
+            return ~self.null_mask
+        raise ValueError(f"unsupported scalar predicate op: {op!r}")
+
+    def _eq(self, value: Any) -> np.ndarray:
+        mask = np.zeros(self.row_count, dtype=bool)
+        normalized = _normalize_value(value, self.dtype)
+        if normalized is None:
+            return mask
+        rows = self.value_to_rows.get(normalized)
+        if rows is not None:
+            mask[rows] = True
+        return mask
+
+    def _in(self, values: tuple[Any, ...]) -> np.ndarray:
+        mask = np.zeros(self.row_count, dtype=bool)
+        for value in values:
+            normalized = _normalize_value(value, self.dtype)
+            if normalized is None:
+                continue
+            rows = self.value_to_rows.get(normalized)
+            if rows is not None:
+                mask[rows] = True
+        return mask
+
+    def _range(self, op: str, value: Any) -> np.ndarray:
+        mask = np.zeros(self.row_count, dtype=bool)
+        normalized = _normalize_value(value, self.dtype)
+        if normalized is None or self.sorted_values.size == 0:
+            return mask
+        if op == "<":
+            end = np.searchsorted(self.sorted_values, normalized, side="left")
+            rows = self.sorted_rows[:end]
+        elif op == "<=":
+            end = np.searchsorted(self.sorted_values, normalized, side="right")
+            rows = self.sorted_rows[:end]
+        elif op == ">":
+            start = np.searchsorted(self.sorted_values, normalized, side="right")
+            rows = self.sorted_rows[start:]
+        else:
+            start = np.searchsorted(self.sorted_values, normalized, side="left")
+            rows = self.sorted_rows[start:]
+        mask[rows] = True
+        return mask
+
+
+def _normalize_value(value: Any, dtype: DataType) -> Any:
+    if value is None:
+        return None
+    if dtype == DataType.TIMESTAMPTZ:
+        return parse_timestamptz(value)
+    if dtype in (DataType.INT8, DataType.INT16, DataType.INT32, DataType.INT64):
+        if isinstance(value, bool):
+            return int(value)
+        return int(value)
+    if dtype in (DataType.FLOAT, DataType.DOUBLE):
+        return float(value)
+    if dtype == DataType.BOOL:
+        return bool(value)
+    if dtype == DataType.VARCHAR:
+        return str(value)
+    return value
+
+
+def _numpy_dtype(dtype: DataType):
+    if dtype in (DataType.INT8, DataType.INT16, DataType.INT32, DataType.INT64, DataType.TIMESTAMPTZ):
+        return np.int64
+    if dtype in (DataType.FLOAT, DataType.DOUBLE):
+        return np.float64
+    if dtype == DataType.BOOL:
+        return np.bool_
+    return object
+
+
+def _arrow_type(dtype: DataType):
+    if dtype in (DataType.INT8, DataType.INT16, DataType.INT32, DataType.INT64, DataType.TIMESTAMPTZ):
+        return pa.int64()
+    if dtype in (DataType.FLOAT, DataType.DOUBLE):
+        return pa.float64()
+    if dtype == DataType.BOOL:
+        return pa.bool_()
+    if dtype == DataType.VARCHAR:
+        return pa.string()
+    raise NotImplementedError(f"unsupported scalar index field type {dtype.name}")

--- a/milvus_lite/index/scalar/planner.py
+++ b/milvus_lite/index/scalar/planner.py
@@ -1,0 +1,176 @@
+"""Planner for scalar-index-covered filter expressions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Iterable, Optional, Tuple
+
+import numpy as np
+
+from milvus_lite.search.filter.ast import (
+    And,
+    BoolLit,
+    CmpOp,
+    FieldRef,
+    FloatLit,
+    InOp,
+    IntLit,
+    IsNullOp,
+    ListLit,
+    Or,
+    StringLit,
+    TimestampLit,
+)
+
+
+@dataclass(frozen=True)
+class ScalarPredicate:
+    op: str
+    field_name: str
+    value: Any = None
+    values: Tuple[Any, ...] = ()
+
+
+class IndexedFilterPlan:
+    required_fields: frozenset[str]
+
+    def evaluate(self, indexes: dict[str, Any]) -> np.ndarray:
+        raise NotImplementedError
+
+
+@dataclass(frozen=True)
+class PredicatePlan(IndexedFilterPlan):
+    predicate: ScalarPredicate
+    required_fields: frozenset[str] = field(init=False)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "required_fields", frozenset((self.predicate.field_name,)))
+
+    def evaluate(self, indexes: dict[str, Any]) -> np.ndarray:
+        return indexes[self.predicate.field_name].match(self.predicate)
+
+
+@dataclass(frozen=True)
+class AndPlan(IndexedFilterPlan):
+    operands: Tuple[IndexedFilterPlan, ...]
+    required_fields: frozenset[str] = field(init=False)
+
+    def __post_init__(self) -> None:
+        fields = frozenset()
+        for operand in self.operands:
+            fields |= operand.required_fields
+        object.__setattr__(self, "required_fields", fields)
+
+    def evaluate(self, indexes: dict[str, Any]) -> np.ndarray:
+        out = self.operands[0].evaluate(indexes).copy()
+        if not out.any():
+            return out
+        for operand in self.operands[1:]:
+            out &= operand.evaluate(indexes)
+            if not out.any():
+                return out
+        return out
+
+
+@dataclass(frozen=True)
+class OrPlan(IndexedFilterPlan):
+    operands: Tuple[IndexedFilterPlan, ...]
+    required_fields: frozenset[str] = field(init=False)
+
+    def __post_init__(self) -> None:
+        fields = frozenset()
+        for operand in self.operands:
+            fields |= operand.required_fields
+        object.__setattr__(self, "required_fields", fields)
+
+    def evaluate(self, indexes: dict[str, Any]) -> np.ndarray:
+        out = self.operands[0].evaluate(indexes).copy()
+        if out.all():
+            return out
+        for operand in self.operands[1:]:
+            out |= operand.evaluate(indexes)
+            if out.all():
+                return out
+        return out
+
+
+_REVERSE_OP = {
+    "<": ">",
+    "<=": ">=",
+    ">": "<",
+    ">=": "<=",
+    "==": "==",
+    "!=": "!=",
+}
+
+
+def plan_indexed_filter(compiled, indexed_fields: Iterable[str]) -> Optional[IndexedFilterPlan]:
+    return _plan(compiled.ast, set(indexed_fields))
+
+
+def _plan(node, indexed_fields: set[str]) -> Optional[IndexedFilterPlan]:
+    if isinstance(node, CmpOp):
+        return _plan_cmp(node, indexed_fields)
+    if isinstance(node, InOp):
+        if not isinstance(node.field, FieldRef):
+            return None
+        if node.field.name not in indexed_fields:
+            return None
+        values = _literal_list(node.values)
+        if values is None:
+            return None
+        op = "not in" if node.negate else "in"
+        return PredicatePlan(ScalarPredicate(op=op, field_name=node.field.name, values=values))
+    if isinstance(node, IsNullOp):
+        if not isinstance(node.field, FieldRef):
+            return None
+        if node.field.name not in indexed_fields:
+            return None
+        op = "is not null" if node.negate else "is null"
+        return PredicatePlan(ScalarPredicate(op=op, field_name=node.field.name))
+    if isinstance(node, And):
+        operands = tuple(_plan(op, indexed_fields) for op in node.operands)
+        if any(op is None for op in operands):
+            return None
+        return AndPlan(operands)  # type: ignore[arg-type]
+    if isinstance(node, Or):
+        operands = tuple(_plan(op, indexed_fields) for op in node.operands)
+        if any(op is None for op in operands):
+            return None
+        return OrPlan(operands)  # type: ignore[arg-type]
+    return None
+
+
+def _plan_cmp(node: CmpOp, indexed_fields: set[str]) -> Optional[IndexedFilterPlan]:
+    if isinstance(node.left, FieldRef):
+        field = node.left.name
+        value = _literal_value(node.right)
+        op = node.op
+    elif isinstance(node.right, FieldRef):
+        field = node.right.name
+        value = _literal_value(node.left)
+        op = _REVERSE_OP[node.op]
+    else:
+        return None
+    if field not in indexed_fields or value is _UNSUPPORTED:
+        return None
+    return PredicatePlan(ScalarPredicate(op=op, field_name=field, value=value))
+
+
+_UNSUPPORTED = object()
+
+
+def _literal_value(node) -> Any:
+    if isinstance(node, (IntLit, FloatLit, StringLit, BoolLit, TimestampLit)):
+        return node.value
+    return _UNSUPPORTED
+
+
+def _literal_list(node: ListLit) -> Optional[Tuple[Any, ...]]:
+    values = []
+    for element in node.elements:
+        value = _literal_value(element)
+        if value is _UNSUPPORTED:
+            return None
+        values.append(value)
+    return tuple(values)

--- a/milvus_lite/index/spec.py
+++ b/milvus_lite/index/spec.py
@@ -57,9 +57,9 @@ class IndexSpec:
             raise ValueError(f"field_name must be a non-empty string, got {self.field_name!r}")
         if not isinstance(self.index_type, str) or not self.index_type:
             raise ValueError(f"index_type must be a non-empty string, got {self.index_type!r}")
-        if self.metric_type not in ("COSINE", "L2", "IP", "BM25"):
+        if self.metric_type not in ("COSINE", "L2", "IP", "BM25", "NONE"):
             raise ValueError(
-                f"metric_type must be one of COSINE/L2/IP/BM25, got {self.metric_type!r}"
+                f"metric_type must be one of COSINE/L2/IP/BM25/NONE, got {self.metric_type!r}"
             )
         if not isinstance(self.build_params, (dict, MappingProxyType)):
             raise TypeError(f"build_params must be a dict, got {type(self.build_params).__name__}")

--- a/milvus_lite/search/assembler.py
+++ b/milvus_lite/search/assembler.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING, Any, Iterable, List, Optional, Tuple
 import numpy as np
 
 if TYPE_CHECKING:
+    from milvus_lite.index.scalar import IndexedFilterPlan
     from milvus_lite.search.filter.semantic import CompiledExpr
     from milvus_lite.storage.memtable import MemTable
     from milvus_lite.storage.segment import Segment
@@ -31,6 +32,7 @@ def assemble_candidates(
     vector_field: Optional[str],
     partition_names: Optional[List[str]] = None,
     filter_compiled: Optional["CompiledExpr"] = None,
+    indexed_filter_plan: Optional["IndexedFilterPlan"] = None,
 ) -> Tuple[List[Any], np.ndarray, np.ndarray, List[RecordSource], Optional[np.ndarray]]:
     """Build the unified candidate arrays.
 
@@ -44,7 +46,8 @@ def assemble_candidates(
                         or memtable.materialize_row(*ref) to get the dict.
         filter_mask:    np.ndarray[bool] (length N) or None
     """
-    from milvus_lite.search.filter.eval import evaluate as filter_evaluate
+    from milvus_lite.search.filter import evaluate_mask
+    from milvus_lite.search.indexed_filter import evaluate_segment_filter
 
     partition_filter = set(partition_names) if partition_names else None
 
@@ -66,8 +69,9 @@ def assemble_candidates(
         # Store (segment, row_idx) refs — NO row_to_dict call here
         rec_source_chunks.append([(seg, i) for i in range(seg.num_rows)])
         if filter_compiled is not None:
-            mask = filter_evaluate(filter_compiled, seg.table)
-            filter_chunks.append(mask.to_numpy(zero_copy_only=False))
+            filter_chunks.append(
+                evaluate_segment_filter(seg, filter_compiled, indexed_filter_plan)
+            )
 
     # ── memtable (deferred materialization) ─────────────────────
     mt_pks, mt_seqs, mt_vecs, mt_row_refs, mt_table = memtable.to_search_snapshot(
@@ -82,8 +86,7 @@ def assemble_candidates(
         # Store (memtable, (batch_idx, row_idx)) refs
         rec_source_chunks.append([(memtable, ref) for ref in mt_row_refs])
         if filter_compiled is not None and mt_table is not None:
-            mask = filter_evaluate(filter_compiled, mt_table)
-            filter_chunks.append(mask.to_numpy(zero_copy_only=False))
+            filter_chunks.append(evaluate_mask(filter_compiled, mt_table))
 
     # ── concatenate ─────────────────────────────────────────────
     if not pk_chunks:

--- a/milvus_lite/search/executor_indexed.py
+++ b/milvus_lite/search/executor_indexed.py
@@ -39,6 +39,7 @@ import numpy as np
 from milvus_lite.index.brute_force import BruteForceIndex
 
 if TYPE_CHECKING:
+    from milvus_lite.index.scalar import IndexedFilterPlan
     from milvus_lite.search.filter.semantic import CompiledExpr
     from milvus_lite.storage.delta_index import DeltaIndex
     from milvus_lite.storage.memtable import MemTable
@@ -57,6 +58,7 @@ def execute_search_with_index(
     partition_names: Optional[List[str]] = None,
     compiled_filter: Optional["CompiledExpr"] = None,
     output_fields: Optional[List[str]] = None,
+    indexed_filter_plan: Optional["IndexedFilterPlan"] = None,
 ) -> List[List[dict]]:
     """Per-source recall + global merge search path.
 
@@ -132,13 +134,14 @@ def execute_search_with_index(
     seg_filter_masks: Dict[int, np.ndarray] = {}
     mt_filter_mask: Optional[np.ndarray] = None
     if compiled_filter is not None:
-        from milvus_lite.search.filter.eval import evaluate as filter_evaluate
+        from milvus_lite.search.filter import evaluate_mask
+        from milvus_lite.search.indexed_filter import evaluate_segment_filter
         for seg in in_scope_segments:
-            mask = filter_evaluate(compiled_filter, seg.table)
-            seg_filter_masks[id(seg)] = mask.to_numpy(zero_copy_only=False)
+            seg_filter_masks[id(seg)] = evaluate_segment_filter(
+                seg, compiled_filter, indexed_filter_plan,
+            )
         if mt_pks and mt_table is not None:
-            mask = filter_evaluate(compiled_filter, mt_table)
-            mt_filter_mask = mask.to_numpy(zero_copy_only=False)
+            mt_filter_mask = evaluate_mask(compiled_filter, mt_table)
 
     # ── 3. per-source recall ────────────────────────────────────
     # Per query, accumulate (distance, source_idx, local_id) candidate

--- a/milvus_lite/search/filter/__init__.py
+++ b/milvus_lite/search/filter/__init__.py
@@ -22,6 +22,13 @@ from milvus_lite.search.filter.semantic import CompiledExpr, FieldInfo, compile_
 from milvus_lite.search.filter.eval import evaluate
 
 
+def evaluate_mask(compiled: CompiledExpr, table):
+    mask = evaluate(compiled, table).to_numpy(zero_copy_only=False)
+    if mask.dtype == bool:
+        return mask
+    return mask.astype(bool, copy=False)
+
+
 def compile_filter(
     source: str,
     schema,
@@ -45,6 +52,7 @@ __all__ = [
     "compile_expr",
     "compile_filter",
     "evaluate",
+    "evaluate_mask",
     "CompiledExpr",
     "FieldInfo",
     "FilterError",

--- a/milvus_lite/search/indexed_filter.py
+++ b/milvus_lite/search/indexed_filter.py
@@ -1,0 +1,27 @@
+"""Helpers for scalar-index-backed filter evaluation."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from milvus_lite.index.scalar import IndexedFilterPlan
+    from milvus_lite.search.filter.semantic import CompiledExpr
+    from milvus_lite.storage.segment import Segment
+
+
+def evaluate_segment_filter(
+    seg: "Segment",
+    compiled_filter: "CompiledExpr",
+    indexed_filter_plan: Optional["IndexedFilterPlan"],
+) -> np.ndarray:
+    if indexed_filter_plan is not None:
+        if indexed_filter_plan.required_fields <= seg.scalar_indexes.keys():
+            return indexed_filter_plan.evaluate(seg.scalar_indexes).astype(bool, copy=False)
+    from milvus_lite.search.filter import evaluate_mask
+
+    return evaluate_mask(compiled_filter, seg.table)
+
+

--- a/milvus_lite/storage/segment.py
+++ b/milvus_lite/storage/segment.py
@@ -24,16 +24,19 @@ attaches one.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 import numpy as np
 import pyarrow as pa
 
+from milvus_lite.index.files import index_sidecar_path
 from milvus_lite.storage.data_file import read_data_file
 
 if TYPE_CHECKING:
     from milvus_lite.index.protocol import VectorIndex
+    from milvus_lite.index.scalar import ScalarInvertedIndex
     from milvus_lite.index.spec import IndexSpec
+    from milvus_lite.schema.types import DataType
 
 
 class Segment:
@@ -62,6 +65,7 @@ class Segment:
         "pk_to_row",
         "index",
         "indexes",
+        "scalar_indexes",
         "_pk_field",
         "_vector_field",
     )
@@ -95,6 +99,7 @@ class Segment:
         # self.indexes maps field_name → VectorIndex.
         self.index: Optional["VectorIndex"] = None
         self.indexes: Dict[str, "VectorIndex"] = {}
+        self.scalar_indexes: Dict[str, "ScalarInvertedIndex"] = {}
 
     # ── factory ─────────────────────────────────────────────────
 
@@ -184,6 +189,9 @@ class Segment:
         if field_name == self._vector_field:
             self.index = index
 
+    def attach_scalar_index(self, index: "ScalarInvertedIndex", field_name: str) -> None:
+        self.scalar_indexes[field_name] = index
+
     def release_index(self, field_name: Optional[str] = None) -> None:
         """Drop index reference(s). Memory freed when GC collects.
 
@@ -193,35 +201,23 @@ class Segment:
         if field_name is None:
             self.index = None
             self.indexes.clear()
+            self.scalar_indexes.clear()
         else:
             self.indexes.pop(field_name, None)
+            self.scalar_indexes.pop(field_name, None)
             if field_name == self._vector_field:
                 self.index = None
 
     def index_file_path(
-        self, index_dir: str, index_type: str, field_name: str,
+        self,
+        index_dir: str,
+        index_type: str,
+        field_name: str,
+        *,
+        scalar: bool = False,
     ) -> str:
-        """Return the canonical .idx path for (segment, field, index_type).
-
-        Naming convention (architectural invariant §11):
-            ``<index_dir>/<segment_stem>.<field_name>.<index_type>.idx``
-
-        Example: data file ``data_000001_000500.parquet`` with an HNSW
-        index on the ``dense_vec`` field →
-        ``indexes/data_000001_000500.dense_vec.hnsw.idx``.
-
-        field_name is part of the filename so a single segment can hold
-        multiple indexes (e.g. hybrid-search collections with multiple
-        FLOAT_VECTOR fields, each with its own HNSW).
-
-        Orphan cleanup reverses the parse: strip the .idx suffix, then
-        rpartition twice to recover (stem, field, index_type).
-        """
-        import os
-        stem = os.path.splitext(os.path.basename(self.file_path))[0]
-        return os.path.join(
-            index_dir,
-            f"{stem}.{field_name}.{index_type.lower()}.idx",
+        return index_sidecar_path(
+            index_dir, self.file_path, field_name, index_type, scalar=scalar,
         )
 
     def build_or_load_index(
@@ -270,6 +266,32 @@ class Segment:
             idx.save(path)
 
         self.attach_index(idx, field_name=field_name)
+
+    def build_or_load_scalar_index(
+        self,
+        spec: "IndexSpec",  # type: ignore[name-defined]
+        index_dir: str,
+        dtype: "DataType",  # type: ignore[name-defined]
+    ) -> None:
+        field_name = spec.field_name
+        if field_name in self.scalar_indexes:
+            return
+        if self.num_rows == 0:
+            return
+
+        import os
+        from milvus_lite.index.scalar import ScalarInvertedIndex
+
+        path = self.index_file_path(index_dir, spec.index_type, field_name, scalar=True)
+        if os.path.exists(path):
+            idx = ScalarInvertedIndex.load(path)
+            if idx.field_name != field_name or idx.dtype != dtype:
+                raise ValueError(f"scalar index file metadata does not match {field_name!r}")
+        else:
+            idx = ScalarInvertedIndex.build(self.table, field_name, dtype)
+            os.makedirs(index_dir, exist_ok=True)
+            idx.save(path)
+        self.attach_scalar_index(idx, field_name)
 
     # ── introspection ───────────────────────────────────────────
 

--- a/milvus_lite/storage/snapshots.py
+++ b/milvus_lite/storage/snapshots.py
@@ -14,6 +14,8 @@ import uuid
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Tuple
 
+from milvus_lite.index.files import parse_index_sidecar_name
+
 
 SNAPSHOTS_DIRNAME = "snapshots"
 SNAPSHOT_METADATA_DIRNAME = "metadata"
@@ -227,21 +229,14 @@ def collect_index_files(
             continue
         rels: List[str] = []
         for entry in os.listdir(index_dir):
-            if not entry.endswith(".idx"):
+            sidecar = parse_index_sidecar_name(entry)
+            if sidecar is None:
                 continue
-            stem = _index_source_stem(entry)
-            if stem in stems:
+            if sidecar.source_stem in stems:
                 rels.append(os.path.join("indexes", entry))
         if rels:
             out[partition] = sorted(rels)
     return out
-
-
-def _index_source_stem(filename: str) -> str:
-    base = filename[:-len(".idx")] if filename.endswith(".idx") else filename
-    stem_field, _, _index_type = base.rpartition(".")
-    stem, _, _field_name = stem_field.rpartition(".")
-    return stem or stem_field or base
 
 
 def _validate_rel_path(path: str, allowed_prefixes: Tuple[str, ...]) -> None:

--- a/tests/adapter/test_grpc_index.py
+++ b/tests/adapter/test_grpc_index.py
@@ -18,6 +18,13 @@ def _make_schema():
     return schema
 
 
+def _make_scalar_schema():
+    schema = _make_schema()
+    schema.add_field("age", DataType.INT64, nullable=True)
+    schema.add_field("category", DataType.VARCHAR, max_length=64, nullable=True)
+    return schema
+
+
 def _hnsw_params(client):
     idx = client.prepare_index_params()
     idx.add_index(
@@ -184,3 +191,49 @@ def test_describe_index_empty_when_no_index(milvus_client):
     milvus_client.create_collection("demo", schema=_make_schema())
     desc = milvus_client.describe_index("demo", "vec")
     assert desc is None
+
+
+def test_create_scalar_inverted_index_query_and_search(milvus_client):
+    milvus_client.create_collection("demo", schema=_make_scalar_schema())
+    rows = [
+        {
+            "id": i,
+            "vec": [float(i == j) for j in range(4)],
+            "title": f"t{i}",
+            "age": None if i == 4 else 18 + i,
+            "category": ["tech", "news", "blog", "tech", None][i],
+        }
+        for i in range(5)
+    ]
+    milvus_client.insert("demo", rows)
+    milvus_client.flush("demo")
+
+    idx = milvus_client.prepare_index_params()
+    idx.add_index(field_name="age", index_type="INVERTED")
+    idx.add_index(field_name="category", index_type="INVERTED")
+    milvus_client.create_index("demo", idx)
+
+    age_desc = milvus_client.describe_index("demo", "age")
+    category_desc = milvus_client.describe_index("demo", "category")
+    assert age_desc["index_type"] == "INVERTED"
+    assert age_desc["metric_type"] == "NONE"
+    assert category_desc["index_type"] == "INVERTED"
+    assert category_desc["metric_type"] == "NONE"
+
+    milvus_client.load_collection("demo")
+    rows = milvus_client.query(
+        "demo",
+        filter="age >= 20",
+        output_fields=["age", "category"],
+    )
+    assert {row["id"] for row in rows} == {2, 3}
+
+    results = milvus_client.search(
+        "demo",
+        data=[[1.0, 0.0, 0.0, 0.0]],
+        limit=5,
+        filter="category == 'tech'",
+        output_fields=["category"],
+    )
+    assert [hit["id"] for hit in results[0]] == [0, 3]
+    assert all(hit["entity"]["category"] == "tech" for hit in results[0])

--- a/tests/engine/test_scalar_index.py
+++ b/tests/engine/test_scalar_index.py
@@ -1,0 +1,607 @@
+import os
+
+import pyarrow as pa
+import pytest
+
+from milvus_lite import Collection, CollectionSchema, DataType, FieldSchema
+from milvus_lite.exceptions import SchemaValidationError
+
+
+def _schema():
+    return CollectionSchema(fields=[
+        FieldSchema(name="id", dtype=DataType.INT64, is_primary=True),
+        FieldSchema(name="vec", dtype=DataType.FLOAT_VECTOR, dim=4),
+        FieldSchema(name="age", dtype=DataType.INT64, nullable=True),
+        FieldSchema(name="category", dtype=DataType.VARCHAR, nullable=True, max_length=64),
+        FieldSchema(name="active", dtype=DataType.BOOL, nullable=True),
+    ])
+
+
+def _rows():
+    return [
+        {"id": 1, "vec": [1, 0, 0, 0], "age": 18, "category": "tech", "active": True},
+        {"id": 2, "vec": [0, 1, 0, 0], "age": 25, "category": "news", "active": False},
+        {"id": 3, "vec": [0, 0, 1, 0], "age": 30, "category": "tech", "active": True},
+        {"id": 4, "vec": [0, 0, 0, 1], "age": 50, "category": None, "active": None},
+        {"id": 5, "vec": [1, 1, 0, 0], "age": None, "category": "blog", "active": False},
+    ]
+
+
+def _ids(rows):
+    return [r["id"] for r in rows]
+
+
+def _index_files(data_dir, partition="_default"):
+    index_dir = os.path.join(data_dir, "partitions", partition, "indexes")
+    if not os.path.isdir(index_dir):
+        return []
+    return sorted(os.listdir(index_dir))
+
+
+def test_scalar_index_query_matches_scan(tmp_path):
+    scan = Collection("scan", str(tmp_path / "scan"), _schema())
+    indexed = Collection("indexed", str(tmp_path / "indexed"), _schema())
+    try:
+        scan.insert(_rows())
+        scan.flush()
+        indexed.insert(_rows())
+        indexed.flush()
+        indexed.create_index("age", {"index_type": "INVERTED"})
+        indexed.load()
+
+        exprs = [
+            "age == 25",
+            "age != 25",
+            "age in [18, 30]",
+            "age not in [18, 30]",
+            "age >= 25 and age < 50",
+            "age is null",
+            "age is not null",
+            "not (age == 25)",
+        ]
+        for expr in exprs:
+            assert _ids(indexed.query(expr, output_fields=["id"])) == _ids(
+                scan.query(expr, output_fields=["id"])
+            )
+    finally:
+        scan.close()
+        indexed.close()
+
+
+def test_scalar_index_search_matches_scan(tmp_path):
+    scan = Collection("scan", str(tmp_path / "scan"), _schema())
+    indexed = Collection("indexed", str(tmp_path / "indexed"), _schema())
+    try:
+        scan.insert(_rows())
+        scan.flush()
+        indexed.insert(_rows())
+        indexed.flush()
+        indexed.create_index("category", {"index_type": "INVERTED"})
+        indexed.load()
+
+        query = [[1, 0, 0, 0]]
+        exprs = [
+            "category == 'tech'",
+            "category in ['tech', 'blog']",
+            "category != 'tech'",
+            "category is null",
+        ]
+        for expr in exprs:
+            actual = indexed.search(query, top_k=10, metric_type="L2", expr=expr)
+            expected = scan.search(query, top_k=10, metric_type="L2", expr=expr)
+            assert [h["id"] for h in actual[0]] == [h["id"] for h in expected[0]]
+    finally:
+        scan.close()
+        indexed.close()
+
+
+def test_scalar_index_persistence_and_sidecar(tmp_path):
+    data_dir = tmp_path / "data"
+    col = Collection("c", str(data_dir), _schema())
+    try:
+        col.insert(_rows())
+        col.flush()
+        col.create_index("age", {"index_type": "INVERTED"})
+        col.load()
+        files = os.listdir(data_dir / "partitions" / "_default" / "indexes")
+        assert any(f.endswith(".age.inverted.sidx") for f in files)
+    finally:
+        col.close()
+
+    reopened = Collection("c", str(data_dir), _schema())
+    try:
+        reopened.load()
+        assert _ids(reopened.query("age >= 25", output_fields=["id"])) == [2, 3, 4]
+    finally:
+        reopened.close()
+
+
+def test_scalar_index_compaction_replaces_sidx_files(tmp_path, monkeypatch):
+    monkeypatch.setattr("milvus_lite.engine.compaction.COMPACTION_MIN_FILES_PER_BUCKET", 2)
+
+    data_dir = tmp_path / "data"
+    col = Collection("c", str(data_dir), _schema())
+    try:
+        col.create_index("age", {"index_type": "INVERTED"})
+        col.load()
+
+        for batch in range(3):
+            rows = []
+            for row in _rows():
+                item = dict(row)
+                item["id"] = batch * 100 + item["id"]
+                rows.append(item)
+            col.insert(rows)
+            col.flush()
+        col._wait_for_bg()
+
+        data_files = sorted(os.listdir(data_dir / "partitions" / "_default" / "data"))
+        sidx_files = [f for f in _index_files(str(data_dir)) if f.endswith(".age.inverted.sidx")]
+        data_stems = {os.path.splitext(f)[0] for f in data_files}
+        sidx_stems = {f[: -len(".age.inverted.sidx")] for f in sidx_files}
+        assert data_stems == sidx_stems
+        assert len(sidx_files) < 3
+    finally:
+        col.close()
+
+
+def test_scalar_index_query_and_search_match_scan_after_compaction(tmp_path, monkeypatch):
+    monkeypatch.setattr("milvus_lite.engine.compaction.COMPACTION_MIN_FILES_PER_BUCKET", 2)
+
+    scan = Collection("scan", str(tmp_path / "scan"), _schema())
+    indexed = Collection("indexed", str(tmp_path / "indexed"), _schema())
+    try:
+        for batch in range(3):
+            rows = []
+            for row in _rows():
+                item = dict(row)
+                item["id"] = batch * 100 + item["id"]
+                rows.append(item)
+            scan.insert(rows)
+            scan.flush()
+            indexed.insert(rows)
+            indexed.flush()
+
+        indexed.create_index("age", {"index_type": "INVERTED"})
+        indexed.load()
+        scan._wait_for_bg()
+        indexed._wait_for_bg()
+
+        exprs = [
+            "age == 25",
+            "age != 25",
+            "age in [18, 30]",
+            "age not in [18, 30]",
+            "age >= 25 and age < 50",
+            "age is null",
+            "age is not null",
+        ]
+        for expr in exprs:
+            assert _ids(indexed.query(expr, output_fields=["id"])) == _ids(
+                scan.query(expr, output_fields=["id"])
+            )
+
+            actual = indexed.search([[1, 0, 0, 0]], top_k=20, metric_type="L2", expr=expr)
+            expected = scan.search([[1, 0, 0, 0]], top_k=20, metric_type="L2", expr=expr)
+            assert [h["id"] for h in actual[0]] == [h["id"] for h in expected[0]]
+    finally:
+        scan.close()
+        indexed.close()
+
+
+def test_unimplemented_milvus_scalar_index_type_is_rejected(tmp_path):
+    col = Collection("c", str(tmp_path / "data"), _schema())
+    try:
+        with pytest.raises(SchemaValidationError, match="not implemented"):
+            col.create_index("age", {"index_type": "BITMAP"})
+    finally:
+        col.close()
+
+
+def test_scalar_index_params_do_not_expose_internal_dtype(tmp_path):
+    col = Collection("c", str(tmp_path / "data"), _schema())
+    try:
+        col.create_index("age", {"index_type": "INVERTED"})
+        info = col.get_index_info("age")
+        assert info is not None
+        assert info["build_params"] == {}
+    finally:
+        col.close()
+
+
+_ALL_SCALAR_FIELDS = [
+    "int8_value",
+    "int16_value",
+    "int32_value",
+    "int64_value",
+    "float_value",
+    "double_value",
+    "string_value",
+    "bool_value",
+]
+
+
+def _all_scalar_schema():
+    return CollectionSchema(fields=[
+        FieldSchema(name="id", dtype=DataType.INT64, is_primary=True),
+        FieldSchema(name="vec", dtype=DataType.FLOAT_VECTOR, dim=4),
+        FieldSchema(name="int8_value", dtype=DataType.INT8, nullable=True),
+        FieldSchema(name="int16_value", dtype=DataType.INT16, nullable=True),
+        FieldSchema(name="int32_value", dtype=DataType.INT32, nullable=True),
+        FieldSchema(name="int64_value", dtype=DataType.INT64, nullable=True),
+        FieldSchema(name="float_value", dtype=DataType.FLOAT, nullable=True),
+        FieldSchema(name="double_value", dtype=DataType.DOUBLE, nullable=True),
+        FieldSchema(name="string_value", dtype=DataType.VARCHAR, nullable=True, max_length=64),
+        FieldSchema(name="bool_value", dtype=DataType.BOOL, nullable=True),
+    ])
+
+
+def _all_scalar_rows(count=12):
+    rows = []
+    for i in range(count):
+        is_null = i % 5 == 0
+        rows.append({
+            "id": i,
+            "vec": [float(i == 0), float(i == 1), float(i == 2), float(i == 3)],
+            "int8_value": None if is_null else i % 7,
+            "int16_value": None if is_null else i * 2,
+            "int32_value": None if is_null else i * 3,
+            "int64_value": None if is_null else i * 10,
+            "float_value": None if is_null else float(i % 4) + 0.5,
+            "double_value": None if is_null else float(i % 6) + 0.25,
+            "string_value": None if is_null else f"str_{i % 4}",
+            "bool_value": None if is_null else i % 2 == 0,
+        })
+    return rows
+
+
+def test_create_inverted_index_on_all_supported_scalar_fields(tmp_path):
+    col = Collection("c", str(tmp_path / "data"), _all_scalar_schema())
+    try:
+        col.insert(_all_scalar_rows())
+        col.flush()
+        for field_name in _ALL_SCALAR_FIELDS:
+            col.create_index(field_name, {"index_type": "INVERTED"})
+            assert col.has_index(field_name)
+            info = col.get_index_info(field_name)
+            assert info is not None
+            assert info["index_type"] == "INVERTED"
+            assert info["metric_type"] == "NONE"
+        assert col.list_indexes() == sorted(_ALL_SCALAR_FIELDS)
+    finally:
+        col.close()
+
+
+def test_create_multiple_inverted_indexes_builds_sidecars(tmp_path):
+    data_dir = tmp_path / "data"
+    col = Collection("c", str(data_dir), _all_scalar_schema())
+    indexed_fields = ["int8_value", "int32_value", "string_value"]
+    try:
+        col.insert(_all_scalar_rows())
+        col.flush()
+        for field_name in indexed_fields:
+            col.create_index(field_name, {"index_type": "INVERTED"})
+        col.load()
+
+        files = _index_files(str(data_dir))
+        for field_name in indexed_fields:
+            assert any(f.endswith(f".{field_name}.inverted.sidx") for f in files)
+    finally:
+        col.close()
+
+
+def test_create_string_index_before_load(tmp_path):
+    col = Collection("c", str(tmp_path / "data"), _all_scalar_schema())
+    try:
+        col.insert(_all_scalar_rows())
+        col.flush()
+        col.release()
+        col.create_index("string_value", {"index_type": "INVERTED"})
+        col.create_index("vec", {"index_type": "FLAT", "metric_type": "L2"})
+        col.load()
+
+        assert _ids(col.query("string_value == 'str_1'", output_fields=["id"])) == [1, 9]
+    finally:
+        col.close()
+
+
+def test_load_after_create_string_index(tmp_path):
+    col = Collection("c", str(tmp_path / "data"), _all_scalar_schema())
+    try:
+        col.insert(_all_scalar_rows())
+        col.flush()
+        col.release()
+        col.create_index("vec", {"index_type": "FLAT", "metric_type": "L2"})
+        col.create_index("string_value", {"index_type": "INVERTED"})
+        col.load()
+
+        actual = col.search(
+            [[1, 0, 0, 0]],
+            top_k=10,
+            metric_type="L2",
+            expr="string_value in ['str_0', 'str_2']",
+            output_fields=["id", "string_value"],
+        )
+        assert {hit["id"] for hit in actual[0]} == {2, 4, 6, 8}
+    finally:
+        col.close()
+
+
+def test_scalar_index_consistency_l1_core_types(tmp_path):
+    schema = CollectionSchema(fields=[
+        FieldSchema(name="id", dtype=DataType.INT64, is_primary=True),
+        FieldSchema(name="vec", dtype=DataType.FLOAT_VECTOR, dim=4),
+        FieldSchema(name="int64_no_index", dtype=DataType.INT64, nullable=True),
+        FieldSchema(name="int64_inverted", dtype=DataType.INT64, nullable=True),
+        FieldSchema(name="varchar_no_index", dtype=DataType.VARCHAR, nullable=True, max_length=64),
+        FieldSchema(name="varchar_inverted", dtype=DataType.VARCHAR, nullable=True, max_length=64),
+        FieldSchema(name="float_no_index", dtype=DataType.FLOAT, nullable=True),
+        FieldSchema(name="float_inverted", dtype=DataType.FLOAT, nullable=True),
+        FieldSchema(name="bool_no_index", dtype=DataType.BOOL, nullable=True),
+        FieldSchema(name="bool_inverted", dtype=DataType.BOOL, nullable=True),
+    ])
+    rows = []
+    for i in range(30):
+        is_null = i % 7 == 0
+        int_value = None if is_null else i % 9
+        varchar_value = None if is_null else f"str_{i % 5}"
+        float_value = None if is_null else float(i % 6) + 0.5
+        bool_value = None if is_null else i % 2 == 0
+        rows.append({
+            "id": i,
+            "vec": [float(i == 0), float(i == 1), float(i == 2), float(i == 3)],
+            "int64_no_index": int_value,
+            "int64_inverted": int_value,
+            "varchar_no_index": varchar_value,
+            "varchar_inverted": varchar_value,
+            "float_no_index": float_value,
+            "float_inverted": float_value,
+            "bool_no_index": bool_value,
+            "bool_inverted": bool_value,
+        })
+
+    col = Collection("c", str(tmp_path / "data"), schema)
+    try:
+        col.insert(rows)
+        col.flush()
+        for field_name in ["int64_inverted", "varchar_inverted", "float_inverted", "bool_inverted"]:
+            col.create_index(field_name, {"index_type": "INVERTED"})
+        col.load()
+
+        cases = [
+            ("int64_no_index", "int64_inverted", ["{f} > 3", "{f} <= 4", "{f} == 5", "{f} in [1, 3, 5]", "{f} is null", "{f} is not null"]),
+            ("varchar_no_index", "varchar_inverted", ["{f} == 'str_2'", "{f} != 'str_2'", "{f} in ['str_1', 'str_3']", "{f} not in ['str_4']", "{f} is null", "{f} is not null"]),
+            ("float_no_index", "float_inverted", ["{f} > 2.5", "{f} <= 3.5", "{f} == 4.5", "{f} in [1.5, 3.5]", "{f} is null", "{f} is not null"]),
+            ("bool_no_index", "bool_inverted", ["{f} == true", "{f} == false", "{f} is null", "{f} is not null"]),
+        ]
+        for scan_field, indexed_field, templates in cases:
+            for template in templates:
+                expected = sorted(_ids(col.query(template.format(f=scan_field), output_fields=["id"])))
+                actual = sorted(_ids(col.query(template.format(f=indexed_field), output_fields=["id"])))
+                assert actual == expected
+    finally:
+        col.close()
+
+
+def test_drop_index_removes_scalar_sidx_files(tmp_path):
+    data_dir = tmp_path / "data"
+    col = Collection("c", str(data_dir), _schema())
+    try:
+        col.insert(_rows())
+        col.flush()
+        col.create_index("age", {"index_type": "INVERTED"})
+        col.load()
+        assert any(f.endswith(".age.inverted.sidx") for f in _index_files(str(data_dir)))
+
+        col.release()
+        col.drop_index("age")
+
+        assert not any(f.endswith(".age.inverted.sidx") for f in _index_files(str(data_dir)))
+    finally:
+        col.close()
+
+
+def test_recovery_cleans_orphan_scalar_sidx(tmp_path):
+    data_dir = tmp_path / "data"
+    col = Collection("c", str(data_dir), _schema())
+    col.insert(_rows())
+    col.flush()
+    col.create_index("age", {"index_type": "INVERTED"})
+    col.load()
+    col.close()
+
+    index_dir = data_dir / "partitions" / "_default" / "indexes"
+    orphan = index_dir / "data_999999_999999.age.inverted.sidx"
+    orphan.write_bytes(b"orphan")
+    assert orphan.exists()
+
+    reopened = Collection("c", str(data_dir), _schema())
+    try:
+        assert not orphan.exists()
+        assert any(f.endswith(".age.inverted.sidx") for f in _index_files(str(data_dir)))
+    finally:
+        reopened.close()
+
+
+def test_recovery_keeps_valid_scalar_sidx(tmp_path):
+    data_dir = tmp_path / "data"
+    col = Collection("c", str(data_dir), _schema())
+    col.insert(_rows())
+    col.flush()
+    col.create_index("age", {"index_type": "INVERTED"})
+    col.load()
+    files_before = set(_index_files(str(data_dir)))
+    col.close()
+
+    reopened = Collection("c", str(data_dir), _schema())
+    try:
+        assert set(_index_files(str(data_dir))) == files_before
+        reopened.load()
+        assert _ids(reopened.query("age >= 25", output_fields=["id"])) == [2, 3, 4]
+    finally:
+        reopened.close()
+
+
+def test_flush_after_load_indexes_new_scalar_segments(tmp_path):
+    data_dir = tmp_path / "data"
+    col = Collection("c", str(data_dir), _schema())
+    try:
+        col.create_index("age", {"index_type": "INVERTED"})
+        col.load()
+
+        col.insert(_rows())
+        col.flush()
+        col._wait_for_bg()
+        files_after_first_flush = set(_index_files(str(data_dir)))
+        assert any(f.endswith(".age.inverted.sidx") for f in files_after_first_flush)
+
+        newer = []
+        for row in _rows():
+            item = dict(row)
+            item["id"] += 100
+            item["age"] = 60
+            newer.append(item)
+        col.insert(newer)
+        col.flush()
+        col._wait_for_bg()
+
+        files_after_second_flush = set(_index_files(str(data_dir)))
+        assert files_after_second_flush - files_after_first_flush
+        assert _ids(col.query("age == 60", output_fields=["id"])) == [101, 102, 103, 104, 105]
+    finally:
+        col.close()
+
+
+def test_load_rejects_scalar_sidx_field_metadata_mismatch(tmp_path):
+    data_dir = tmp_path / "data"
+    col = Collection("c", str(data_dir), _schema())
+    try:
+        col.insert(_rows())
+        col.flush()
+        col.create_index("age", {"index_type": "INVERTED"})
+        col.load()
+        col.release()
+
+        index_dir = data_dir / "partitions" / "_default" / "indexes"
+        sidx_path = next(index_dir.glob("*.age.inverted.sidx"))
+        with pa.memory_map(str(sidx_path), "r") as source:
+            table = pa.ipc.RecordBatchFileReader(source).read_all()
+        metadata = dict(table.schema.metadata or {})
+        metadata[b"field_name"] = b"category"
+        table = table.replace_schema_metadata(metadata)
+        with pa.OSFile(str(sidx_path), "wb") as sink:
+            with pa.ipc.RecordBatchFileWriter(sink, table.schema) as writer:
+                writer.write_table(table)
+
+        with pytest.raises(ValueError, match="metadata does not match"):
+            col.load()
+    finally:
+        col.close()
+
+
+def test_load_rejects_scalar_sidx_dtype_metadata_mismatch(tmp_path):
+    data_dir = tmp_path / "data"
+    col = Collection("c", str(data_dir), _schema())
+    try:
+        col.insert(_rows())
+        col.flush()
+        col.create_index("age", {"index_type": "INVERTED"})
+        col.load()
+        col.release()
+
+        index_dir = data_dir / "partitions" / "_default" / "indexes"
+        sidx_path = next(index_dir.glob("*.age.inverted.sidx"))
+        with pa.memory_map(str(sidx_path), "r") as source:
+            table = pa.ipc.RecordBatchFileReader(source).read_all()
+        metadata = dict(table.schema.metadata or {})
+        metadata[b"dtype"] = b"VARCHAR"
+        table = table.replace_schema_metadata(metadata)
+        with pa.OSFile(str(sidx_path), "wb") as sink:
+            with pa.ipc.RecordBatchFileWriter(sink, table.schema) as writer:
+                writer.write_table(table)
+
+        with pytest.raises(ValueError, match="metadata does not match"):
+            col.load()
+    finally:
+        col.close()
+
+
+def test_drop_scalar_index_keeps_vector_idx_files(tmp_path):
+    data_dir = tmp_path / "data"
+    col = Collection("c", str(data_dir), _schema())
+    try:
+        col.insert(_rows())
+        col.flush()
+        col.create_index("vec", {"index_type": "FLAT", "metric_type": "L2"})
+        col.create_index("age", {"index_type": "INVERTED"})
+        col.load()
+        index_files_before = set(_index_files(str(data_dir)))
+        assert any(f.endswith(".vec.flat.idx") for f in index_files_before)
+        assert any(f.endswith(".age.inverted.sidx") for f in index_files_before)
+
+        col.release()
+        col.drop_index("age")
+
+        index_files_after = set(_index_files(str(data_dir)))
+        assert any(f.endswith(".vec.flat.idx") for f in index_files_after)
+        assert not any(f.endswith(".age.inverted.sidx") for f in index_files_after)
+        col.load()
+        hits = col.search([[1, 0, 0, 0]], top_k=1, metric_type="L2")
+        assert hits[0][0]["id"] == 1
+    finally:
+        col.close()
+
+
+def test_drop_vector_index_keeps_scalar_sidx_files(tmp_path):
+    data_dir = tmp_path / "data"
+    col = Collection("c", str(data_dir), _schema())
+    try:
+        col.insert(_rows())
+        col.flush()
+        col.create_index("vec", {"index_type": "FLAT", "metric_type": "L2"})
+        col.create_index("age", {"index_type": "INVERTED"})
+        col.load()
+        index_files_before = set(_index_files(str(data_dir)))
+        assert any(f.endswith(".vec.flat.idx") for f in index_files_before)
+        assert any(f.endswith(".age.inverted.sidx") for f in index_files_before)
+
+        col.release()
+        col.drop_index("vec")
+
+        index_files_after = set(_index_files(str(data_dir)))
+        assert not any(f.endswith(".vec.flat.idx") for f in index_files_after)
+        assert any(f.endswith(".age.inverted.sidx") for f in index_files_after)
+        col.load()
+        assert _ids(col.query("age >= 25", output_fields=["id"])) == [2, 3, 4]
+    finally:
+        col.close()
+
+
+def test_recovery_cleans_orphan_idx_and_sidx_independently(tmp_path):
+    data_dir = tmp_path / "data"
+    col = Collection("c", str(data_dir), _schema())
+    col.insert(_rows())
+    col.flush()
+    col.create_index("vec", {"index_type": "FLAT", "metric_type": "L2"})
+    col.create_index("age", {"index_type": "INVERTED"})
+    col.load()
+    valid_files = set(_index_files(str(data_dir)))
+    col.close()
+
+    index_dir = data_dir / "partitions" / "_default" / "indexes"
+    orphan_idx = index_dir / "data_999999_999999.vec.flat.idx"
+    orphan_sidx = index_dir / "data_999999_999999.age.inverted.sidx"
+    orphan_idx.write_bytes(b"orphan")
+    orphan_sidx.write_bytes(b"orphan")
+
+    reopened = Collection("c", str(data_dir), _schema())
+    try:
+        assert not orphan_idx.exists()
+        assert not orphan_sidx.exists()
+        assert set(_index_files(str(data_dir))) == valid_files
+        reopened.load()
+        assert _ids(reopened.query("age >= 25", output_fields=["id"])) == [2, 3, 4]
+        hits = reopened.search([[1, 0, 0, 0]], top_k=1, metric_type="L2")
+        assert hits[0][0]["id"] == 1
+    finally:
+        reopened.close()

--- a/tests/index/test_index_spec.py
+++ b/tests/index/test_index_spec.py
@@ -85,6 +85,16 @@ def test_from_dict_missing_build_params_defaults_empty():
 # ── Validation ──────────────────────────────────────────────────────
 
 
+def test_none_metric_type_allowed_for_scalar_indexes():
+    spec = IndexSpec(
+        field_name="age",
+        index_type="INVERTED",
+        metric_type="NONE",
+        build_params={},
+    )
+    assert spec.metric_type == "NONE"
+
+
 @pytest.mark.parametrize("bad_metric", ["cosine", "l2", "ip", "FOO", ""])
 def test_invalid_metric_type_raises(bad_metric):
     with pytest.raises(ValueError, match="metric_type"):

--- a/tests/index/test_scalar_inverted.py
+++ b/tests/index/test_scalar_inverted.py
@@ -1,0 +1,98 @@
+import numpy as np
+import pyarrow as pa
+import pytest
+
+from milvus_lite.index.scalar import ScalarInvertedIndex, ScalarPredicate, plan_indexed_filter
+from milvus_lite.schema.types import CollectionSchema, DataType, FieldSchema
+from milvus_lite.search.filter import compile_filter
+
+
+def _table():
+    return pa.Table.from_pydict({
+        "age": [18, 25, 30, 25, None],
+        "category": ["tech", "news", "tech", None, "blog"],
+        "active": [True, False, True, None, False],
+    })
+
+
+def test_int_equality_and_range():
+    idx = ScalarInvertedIndex.build(_table(), "age", DataType.INT64)
+
+    assert np.flatnonzero(idx.match(ScalarPredicate("==", "age", value=25))).tolist() == [1, 3]
+    assert np.flatnonzero(idx.match(ScalarPredicate(">", "age", value=24))).tolist() == [1, 2, 3]
+    assert np.flatnonzero(idx.match(ScalarPredicate("<=", "age", value=25))).tolist() == [0, 1, 3]
+
+
+def test_in_and_null_semantics():
+    idx = ScalarInvertedIndex.build(_table(), "category", DataType.VARCHAR)
+
+    mask = idx.match(ScalarPredicate("in", "category", values=("tech", "blog")))
+    assert np.flatnonzero(mask).tolist() == [0, 2, 4]
+
+    mask = idx.match(ScalarPredicate("!=", "category", value="tech"))
+    assert np.flatnonzero(mask).tolist() == [1, 4]
+
+    mask = idx.match(ScalarPredicate("not in", "category", values=("tech",)))
+    assert np.flatnonzero(mask).tolist() == [1, 3, 4]
+
+    mask = idx.match(ScalarPredicate("is null", "category"))
+    assert np.flatnonzero(mask).tolist() == [3]
+
+
+def test_save_load_round_trip(tmp_path):
+    idx = ScalarInvertedIndex.build(_table(), "age", DataType.INT64)
+    path = tmp_path / "age.sidx"
+    idx.save(str(path))
+
+    loaded = ScalarInvertedIndex.load(str(path))
+    mask = loaded.match(ScalarPredicate("in", "age", values=(18, 30)))
+    assert np.flatnonzero(mask).tolist() == [0, 2]
+
+
+def test_load_rejects_corrupt_file(tmp_path):
+    path = tmp_path / "age.sidx"
+    path.write_bytes(b"not an arrow ipc file")
+
+    with pytest.raises(Exception):
+        ScalarInvertedIndex.load(str(path))
+
+
+def test_load_rejects_unsupported_version(tmp_path):
+    idx = ScalarInvertedIndex.build(_table(), "age", DataType.INT64)
+    path = tmp_path / "age.sidx"
+    idx.save(str(path))
+
+    with pa.memory_map(str(path), "r") as source:
+        table = pa.ipc.RecordBatchFileReader(source).read_all()
+    metadata = dict(table.schema.metadata or {})
+    metadata[b"milvus_lite.scalar_index.version"] = b"999"
+    table = table.replace_schema_metadata(metadata)
+    with pa.OSFile(str(path), "wb") as sink:
+        with pa.ipc.RecordBatchFileWriter(sink, table.schema) as writer:
+            writer.write_table(table)
+
+    with pytest.raises(ValueError, match="unsupported scalar index file version"):
+        ScalarInvertedIndex.load(str(path))
+
+
+def test_planner_does_not_plan_generic_not():
+    schema = CollectionSchema(fields=[
+        FieldSchema(name="id", dtype=DataType.INT64, is_primary=True),
+        FieldSchema(name="age", dtype=DataType.INT64, nullable=True),
+    ])
+    compiled = compile_filter("not (age == 25)", schema)
+
+    assert plan_indexed_filter(compiled, {"age"}) is None
+
+
+def test_planner_falls_back_for_dynamic_field_in_and_null():
+    schema = CollectionSchema(
+        fields=[
+            FieldSchema(name="id", dtype=DataType.INT64, is_primary=True),
+            FieldSchema(name="age", dtype=DataType.INT64, nullable=True),
+        ],
+        enable_dynamic_field=True,
+    )
+
+    assert plan_indexed_filter(compile_filter("color in ['red']", schema), {"age"}) is None
+    assert plan_indexed_filter(compile_filter("color is null", schema), {"age"}) is None

--- a/tests/index/test_sparse_inverted.py
+++ b/tests/index/test_sparse_inverted.py
@@ -174,27 +174,30 @@ class TestSparseInvertedIndex:
 # ---------------------------------------------------------------------------
 
 class TestBM25EndToEnd:
-    def _make_collection(self, tmpdir):
+    def _make_collection(self, tmpdir, *, with_age=False):
         from milvus_lite.schema.types import (
             CollectionSchema, DataType, FieldSchema,
             Function, FunctionType,
         )
         from milvus_lite.engine.collection import Collection
 
+        fields = [
+            FieldSchema(name="id", dtype=DataType.INT64, is_primary=True),
+            FieldSchema(
+                name="text", dtype=DataType.VARCHAR,
+                enable_analyzer=True,
+                analyzer_params={"tokenizer": "standard"},
+            ),
+            FieldSchema(name="vec", dtype=DataType.FLOAT_VECTOR, dim=4),
+            FieldSchema(
+                name="sparse_emb", dtype=DataType.SPARSE_FLOAT_VECTOR,
+                is_function_output=True,
+            ),
+        ]
+        if with_age:
+            fields.append(FieldSchema(name="age", dtype=DataType.INT64, nullable=True))
         schema = CollectionSchema(
-            fields=[
-                FieldSchema(name="id", dtype=DataType.INT64, is_primary=True),
-                FieldSchema(
-                    name="text", dtype=DataType.VARCHAR,
-                    enable_analyzer=True,
-                    analyzer_params={"tokenizer": "standard"},
-                ),
-                FieldSchema(name="vec", dtype=DataType.FLOAT_VECTOR, dim=4),
-                FieldSchema(
-                    name="sparse_emb", dtype=DataType.SPARSE_FLOAT_VECTOR,
-                    is_function_output=True,
-                ),
-            ],
+            fields=fields,
             functions=[
                 Function(
                     name="bm25_fn",
@@ -206,8 +209,8 @@ class TestBM25EndToEnd:
         )
         return Collection(name="test_bm25", data_dir=tmpdir, schema=schema)
 
-    def _record(self, id, text):
-        return {"id": id, "text": text, "vec": [1.0, 0.0, 0.0, 0.0]}
+    def _record(self, id, text, **fields):
+        return {"id": id, "text": text, "vec": [1.0, 0.0, 0.0, 0.0], **fields}
 
     def test_basic_bm25_search(self):
         """Insert documents, search by text, verify relevance ordering."""
@@ -312,6 +315,34 @@ class TestBM25EndToEnd:
             assert 1 not in hit_ids
             assert 2 in hit_ids
             assert 3 in hit_ids
+
+    def test_search_with_scalar_index_filter(self, monkeypatch):
+        with tempfile.TemporaryDirectory() as d:
+            col = self._make_collection(d, with_age=True)
+            col.insert([
+                self._record(1, "hello world", age=18),
+                self._record(2, "hello there", age=25),
+                self._record(3, "hello again", age=30),
+                self._record(4, "other words", age=None),
+            ])
+            col.flush()
+            col.create_index("age", {"index_type": "INVERTED"})
+            col.load()
+
+            def fail_scan_filter(*args, **kwargs):
+                raise AssertionError("segment filter should use scalar index")
+
+            monkeypatch.setattr("milvus_lite.search.filter.evaluate_mask", fail_scan_filter)
+            query_vectors: list = ["hello"]
+            results = col.search(
+                query_vectors=query_vectors,
+                top_k=10,
+                metric_type="BM25",
+                anns_field="sparse_emb",
+                expr="age >= 25",
+                output_fields=["age"],
+            )
+            assert [hit["id"] for hit in results[0]] == [2, 3]
 
     def test_search_output_fields(self):
         """output_fields controls which fields appear in entity."""

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -287,6 +287,36 @@ def test_startup_maintenance_compacts_existing_files(tmp_path, monkeypatch, sche
         db.close()
 
 
+def test_snapshot_pins_scalar_index_files_after_drop_index(tmp_path):
+    scalar_schema = CollectionSchema(fields=[
+        FieldSchema(name="id", dtype=DataType.INT64, is_primary=True),
+        FieldSchema(name="vec", dtype=DataType.FLOAT_VECTOR, dim=4),
+        FieldSchema(name="age", dtype=DataType.INT64, nullable=True),
+    ])
+    db = MilvusLite(str(tmp_path / "db"))
+    try:
+        col = db.create_collection("docs", scalar_schema)
+        col.insert([
+            {"id": 1, "vec": [1.0, 0.0, 0.0, 0.0], "age": 18},
+            {"id": 2, "vec": [0.0, 1.0, 0.0, 0.0], "age": 25},
+        ])
+        col.flush()
+        col.create_index("age", {"index_type": "INVERTED"})
+        snap = db.create_snapshot("docs", "snap_a")
+        pinned = snap["index_files"]["_default"][0]
+        pinned_path = tmp_path / "db" / "collections" / "docs" / "partitions" / "_default" / pinned
+
+        col.release()
+        col.drop_index("age")
+
+        assert os.path.exists(pinned_path)
+        restored = db.restore_snapshot("docs", "snap_a", "docs_restored")
+        restored.load()
+        assert restored.query("age >= 20", output_fields=["id"]) == [{"id": 2}]
+    finally:
+        db.close()
+
+
 def test_snapshot_pins_index_files_after_drop_index(tmp_path, schema):
     db = MilvusLite(str(tmp_path / "db"))
     try:


### PR DESCRIPTION
  Add scalar INVERTED index creation, persistence, recovery, and query/search
  filter acceleration. Extend index spec handling, sidecar file management,
  snapshot references, and gRPC index parameter translation to support scalar
  indexes alongside existing vector indexes.

  Also add scalar index tests, snapshot coverage, and a demo for indexed scalar
  filter queries.