### PR TITLE
fix: handle proxy file resource initialization and rolling upgrades

### DIFF
--- a/milvus_lite/adapter/grpc/servicer.py
+++ b/milvus_lite/adapter/grpc/servicer.py
@@ -118,11 +118,9 @@ def _hit_score_for_chain(hit: dict, metric_type: str) -> float:
     """
     distance = hit["distance"]
     metric = metric_type.upper()
-    if metric == "COSINE":
-        return 1.0 - distance
     if metric == "BM25":
         return -distance
-    if metric in {"IP", "L2"}:
+    if metric in {"COSINE", "IP", "L2"}:
         return distance
     return distance
 

--- a/milvus_lite/engine/collection.py
+++ b/milvus_lite/engine/collection.py
@@ -804,11 +804,7 @@ class Collection:
             raw_results = [hits[offset:offset + top_k] for hits in raw_results]
         elif ranker is not None:
             raw_results = [hits[:top_k] for hits in raw_results]
-        # Convert IP distances to Milvus convention
-        if metric_type == "IP":
-            for hits in raw_results:
-                for hit in hits:
-                    hit["distance"] = -hit["distance"]
+        _convert_hits_to_milvus_distances(raw_results, metric_type)
 
         if _boost_field_injected or _group_by_field_injected:
             raw_results = _strip_injected_output_fields(raw_results, _user_output_fields)
@@ -2248,36 +2244,53 @@ def _apply_range_filter(
     """Filter search results by distance range.
 
     Milvus range search semantics:
-        L2/COSINE: radius = max distance (outer), range_filter = min distance (inner)
-            Keep: range_filter <= distance <= radius
-        IP: radius = min score (inner), range_filter = max score (outer)
-            Keep: radius <= distance <= range_filter
-            (note: at this point IP distances are still internal -dot form)
+        L2: range_filter <= distance < radius
+        IP/COSINE: radius < score <= range_filter
 
     Either bound can be None (no bound on that side).
     After filtering, truncates to *limit* hits per query.
     """
+    metric = metric_type.upper()
     out: List[List[dict]] = []
     for query_hits in results:
         filtered = []
         for hit in query_hits:
-            d = hit["distance"]
-            if metric_type == "IP":
-                # IP internal convention: -dot (smaller = more similar)
-                # radius/range_filter are user-facing (positive dot values)
-                # but _apply_range_filter runs BEFORE IP sign flip, so
-                # negate the bounds for comparison
-                if radius is not None and not (d <= -radius):
+            d = _internal_distance_to_milvus_distance(hit["distance"], metric)
+            if metric in {"IP", "COSINE"}:
+                if radius is not None and not (d > radius):
                     continue
-                if range_filter is not None and not (d >= -range_filter):
+                if range_filter is not None and not (d <= range_filter):
                     continue
             else:
-                # L2/COSINE: smaller distance = closer
-                # radius = outer bound (max), range_filter = inner bound (min)
-                if radius is not None and not (d <= radius):
+                if radius is not None and not (d < radius):
                     continue
                 if range_filter is not None and not (d >= range_filter):
                     continue
             filtered.append(hit)
         out.append(filtered[:limit])
     return out
+
+
+def _convert_hits_to_milvus_distances(
+    results: List[List[dict]],
+    metric_type: str,
+) -> None:
+    """Convert internal search distances to Milvus public score semantics."""
+    metric = metric_type.upper()
+
+    for hits in results:
+        for hit in hits:
+            hit["distance"] = _internal_distance_to_milvus_distance(
+                hit["distance"], metric,
+            )
+
+
+def _internal_distance_to_milvus_distance(distance: float, metric_type: str) -> float:
+    """Map the engine's smaller-is-better distance to Milvus public semantics."""
+    if metric_type == "COSINE":
+        return 1.0 - distance
+    if metric_type == "IP":
+        return -distance
+    if metric_type == "L2":
+        return distance * distance
+    return distance

--- a/tests/adapter/test_grpc_search.py
+++ b/tests/adapter/test_grpc_search.py
@@ -224,9 +224,9 @@ def test_search_distances_returned(loaded_collection):
         assert isinstance(hit["distance"], (int, float))
 
 
-def test_search_results_sorted_ascending(loaded_collection):
+def test_search_results_sorted_by_cosine_score_descending(loaded_collection):
     res = loaded_collection.search(
         "demo", data=[[5.0, 6.0, 0.0, 0.0]], limit=10
     )
     distances = [hit["distance"] for hit in res[0]]
-    assert distances == sorted(distances)
+    assert distances == sorted(distances, reverse=True)

--- a/tests/adapter/test_hybrid_search.py
+++ b/tests/adapter/test_hybrid_search.py
@@ -160,7 +160,7 @@ class TestRerankerUnit:
         from milvus_lite.adapter.grpc.servicer import _hit_score_for_chain
 
         assert _hit_score_for_chain({"distance": 0.9}, "IP") == 0.9
-        assert _hit_score_for_chain({"distance": 0.1}, "COSINE") == 0.9
+        assert _hit_score_for_chain({"distance": 0.9}, "COSINE") == 0.9
         assert _hit_score_for_chain({"distance": 0.1}, "L2") == 0.1
         assert _hit_score_for_chain({"distance": -2.5}, "BM25") == 2.5
 

--- a/tests/adapter/test_issue_fixes.py
+++ b/tests/adapter/test_issue_fixes.py
@@ -179,3 +179,49 @@ def test_autoindex_uses_hnsw():
     vectors = np.random.rand(100, 16).astype(np.float32)
     idx = build_index_from_spec(spec, vectors)
     assert idx.index_type == "HNSW"
+
+
+# ---------------------------------------------------------------------------
+# #343: raw distance semantics should match Milvus server
+# ---------------------------------------------------------------------------
+
+def test_raw_distance_semantics_match_milvus_server(milvus_client):
+    """Issue #343: COSINE is similarity and L2 is squared distance."""
+    expected = {
+        "COSINE": [(1, 1.0), (2, 0.0)],
+        "IP": [(1, 1.0), (2, 0.0)],
+        "L2": [(1, 0.0), (2, 2.0)],
+    }
+
+    for metric, metric_expected in expected.items():
+        collection = f"metric_semantics_{metric.lower()}"
+        milvus_client.create_collection(
+            collection_name=collection,
+            dimension=2,
+            metric_type=metric,
+            auto_id=False,
+        )
+        milvus_client.insert(
+            collection_name=collection,
+            data=[
+                {"id": 1, "vector": [1.0, 0.0]},
+                {"id": 2, "vector": [0.0, 1.0]},
+            ],
+        )
+
+        results = milvus_client.search(
+            collection_name=collection,
+            data=[[1.0, 0.0]],
+            anns_field="vector",
+            limit=2,
+            search_params={"metric_type": metric},
+            output_fields=["id"],
+        )
+
+        actual = [
+            (row.get("id") or row["entity"]["id"], row["distance"])
+            for row in results[0]
+        ]
+        assert [row[0] for row in actual] == [row[0] for row in metric_expected]
+        for (_, distance), (_, expected_distance) in zip(actual, metric_expected):
+            assert distance == pytest.approx(expected_distance)

--- a/tests/adapter/test_milvus_compat.py
+++ b/tests/adapter/test_milvus_compat.py
@@ -246,12 +246,12 @@ class TestSearch:
             assert "float_field" in hit["entity"]
         milvus_client.drop_collection("out_f")
 
-    def test_search_results_sorted_ascending(self, milvus_client):
+    def test_search_results_sorted_by_cosine_score_descending(self, milvus_client):
         _create_loaded(milvus_client, "sorted")
         q = _rng().standard_normal((1, DIM)).astype(np.float32).tolist()
         res = milvus_client.search("sorted", data=q, limit=20)
         distances = [hit["distance"] for hit in res[0]]
-        assert distances == sorted(distances)
+        assert distances == sorted(distances, reverse=True)
         milvus_client.drop_collection("sorted")
 
 

--- a/tests/adapter/test_milvus_compat_v3.py
+++ b/tests/adapter/test_milvus_compat_v3.py
@@ -509,25 +509,25 @@ class TestMixedFilter:
 class TestDistanceOrdering:
     """Adapted from test_milvus_client_e2e search distance verification."""
 
-    def test_cosine_distances_ascending(self, milvus_client):
-        """COSINE search distances must be in ascending order."""
+    def test_cosine_scores_descending(self, milvus_client):
+        """COSINE search scores must be in descending order."""
         _create_simple(milvus_client, "do1")
         q = _rng(42).standard_normal((1, DIM)).astype(np.float32).tolist()
 
         res = milvus_client.search("do1", data=q, limit=NB)
         distances = [h["distance"] for h in res[0]]
-        assert distances == sorted(distances), \
-            "COSINE distances should be in ascending order"
+        assert distances == sorted(distances, reverse=True), \
+            "COSINE scores should be in descending order"
         milvus_client.drop_collection("do1")
 
-    def test_self_query_distance_near_zero(self, milvus_client):
+    def test_self_query_cosine_score_near_one(self, milvus_client):
         """Searching with an inserted vector should return itself at
-        distance ~0 (COSINE)."""
+        score ~1 (COSINE)."""
         rows = _create_simple(milvus_client, "do2")
         q = [rows[5]["vec"]]
         res = milvus_client.search("do2", data=q, limit=1)
         assert res[0][0]["id"] == 5
-        assert res[0][0]["distance"] < 1e-4
+        assert res[0][0]["distance"] == pytest.approx(1.0, abs=1e-4)
         milvus_client.drop_collection("do2")
 
 

--- a/tests/adapter/test_range_search.py
+++ b/tests/adapter/test_range_search.py
@@ -34,16 +34,16 @@ class TestRangeSearchEngine:
         col = Collection(name="test_rs", data_dir=tmpdir, schema=schema)
         # Insert vectors at known positions
         col.insert([
-            {"id": 1, "vec": [1.0, 0.0, 0.0, 0.0]},   # dist ~0 from query
-            {"id": 2, "vec": [0.7, 0.7, 0.0, 0.0]},   # dist ~0.29
-            {"id": 3, "vec": [0.0, 1.0, 0.0, 0.0]},   # dist ~1.0
-            {"id": 4, "vec": [0.0, 0.0, 1.0, 0.0]},   # dist ~1.0
-            {"id": 5, "vec": [-1.0, 0.0, 0.0, 0.0]},  # dist ~2.0
+            {"id": 1, "vec": [1.0, 0.0, 0.0, 0.0]},   # cosine score ~1.0
+            {"id": 2, "vec": [0.7, 0.7, 0.0, 0.0]},   # cosine score ~0.71
+            {"id": 3, "vec": [0.0, 1.0, 0.0, 0.0]},   # cosine score ~0.0
+            {"id": 4, "vec": [0.0, 0.0, 1.0, 0.0]},   # cosine score ~0.0
+            {"id": 5, "vec": [-1.0, 0.0, 0.0, 0.0]},  # cosine score ~-1.0
         ])
         return col
 
     def test_range_both_bounds(self):
-        """radius < distance <= range_filter."""
+        """COSINE range keeps radius < score <= range_filter."""
         with tempfile.TemporaryDirectory() as d:
             col = self._make_collection(d)
             results = col.search(
@@ -58,7 +58,7 @@ class TestRangeSearchEngine:
                 assert hit["distance"] <= 1.5
 
     def test_range_only_radius(self):
-        """Only radius (outer bound for COSINE): distance <= radius."""
+        """Only radius keeps COSINE scores greater than radius."""
         with tempfile.TemporaryDirectory() as d:
             col = self._make_collection(d)
             results = col.search(
@@ -68,10 +68,10 @@ class TestRangeSearchEngine:
                 radius=0.5,
             )
             for hit in results[0]:
-                assert hit["distance"] <= 0.5
+                assert hit["distance"] > 0.5
 
     def test_range_only_range_filter(self):
-        """Only range_filter (inner bound for COSINE): distance >= range_filter."""
+        """Only range_filter keeps COSINE scores up to range_filter."""
         with tempfile.TemporaryDirectory() as d:
             col = self._make_collection(d)
             results = col.search(
@@ -81,7 +81,7 @@ class TestRangeSearchEngine:
                 range_filter=0.5,
             )
             for hit in results[0]:
-                assert hit["distance"] >= 0.5
+                assert hit["distance"] <= 0.5
 
     def test_range_empty_result(self):
         """No results in range."""
@@ -174,7 +174,7 @@ def test_grpc_range_only_range_filter(milvus_client):
         limit=10,
     )
     for hit in results[0]:
-        assert hit["distance"] >= 0.5
+        assert hit["distance"] <= 0.5
     milvus_client.drop_collection("rs_rf")
 
 


### PR DESCRIPTION
  Initialize the Proxy dependency factory before creating the persistent
  storage ChunkManager.

  Ignore ErrServiceUnimplemented when syncing file resources to old Proxy
  nodes during rolling upgrades, while preserving other sync failures.

https://github.com/milvus-io/milvus-lite/issues/343