### PR TITLE
feat(filter): support exists and IS NULL on JSON paths and dynamic fields

### DIFF
--- a/milvus_lite/search/filter/ast.py
+++ b/milvus_lite/search/filter/ast.py
@@ -166,14 +166,21 @@ class LikeOp:
 
 @dataclass(frozen=True)
 class IsNullOp:
-    """`field IS NULL` or `field IS NOT NULL`.
+    """`x IS NULL` / `x IS NOT NULL` / `exists x`. Returns bool.
 
-    The operand must be a FieldRef. Returns bool. Phase F2a only supports
-    plain field refs; JSON path access (`$meta["key"] is null`) lands in F2b.
+    The operand may be a plain FieldRef, a JSON path (PathAccess), or a
+    dynamic-field access (MetaAccess). A missing JSON key and an explicit
+    JSON null both count as null, matching the server.
+
+    `exists x` parses as IsNullOp(negate=True, from_exists=True): the
+    server restricts EXISTS to JSON keys and dynamic fields, and the
+    from_exists marker lets semantic.py enforce the same restriction —
+    the backends evaluate both spellings identically.
     """
-    field: FieldRef
+    field: "Expr"
     negate: bool      # True for "IS NOT NULL"
     pos: int
+    from_exists: bool = False
 
 
 # ── Phase F2b: dynamic field access ─────────────────────────────────────────

--- a/milvus_lite/search/filter/eval/hybrid_backend.py
+++ b/milvus_lite/search/filter/eval/hybrid_backend.py
@@ -229,7 +229,10 @@ def _rewrite_meta_access(node: Expr, keys: Set[str]) -> Expr:
     if isinstance(node, IsNullOp):
         new_field = _rewrite_meta_access(node.field, keys)
         if new_field is not node.field:
-            return IsNullOp(field=new_field, negate=node.negate, pos=node.pos)
+            return IsNullOp(
+                field=new_field, negate=node.negate, pos=node.pos,
+                from_exists=node.from_exists,
+            )
         return node
     # Literals and FieldRef are leaves — return unchanged.
     return node

--- a/milvus_lite/search/filter/eval/python_backend.py
+++ b/milvus_lite/search/filter/eval/python_backend.py
@@ -220,8 +220,11 @@ def _eval_row(node, row: dict) -> Any:
         return regex.match(value) is not None
 
     if isinstance(node, IsNullOp):
-        # IS NULL on a missing key in row dict counts as null too.
-        val = row.get(node.field.name)
+        # The operand may be a FieldRef, PathAccess, or MetaAccess; all
+        # three evaluate missing data to None, so a missing column value,
+        # a missing JSON key, and an explicit JSON null all count as
+        # null — matching the server for IS NULL and exists alike.
+        val = _eval_row(node.field, row)
         is_null = val is None
         return (not is_null) if node.negate else is_null
 

--- a/milvus_lite/search/filter/parser.py
+++ b/milvus_lite/search/filter/parser.py
@@ -251,16 +251,19 @@ class Parser:
     def _parse_is_null_tail(self, left: Expr) -> Expr:
         """`<field> IS NULL` or `<field> IS NOT NULL`.
 
-        IS NULL only applies to a FieldRef LHS. Anything else is a
-        compile-time error in semantic.py — but we already enforce the
-        FieldRef constraint here at parse time for a more direct error.
+        The LHS may be a plain field reference, a JSON path
+        (`metadata["key"] is null`), or a dynamic-field access
+        (`$meta["key"] is null`) — matching the server, which treats a
+        missing JSON key and an explicit null the same way. Anything
+        else is rejected here for a more direct error than semantic.py
+        would give.
         """
         is_tok = self._consume()  # IS
-        if not isinstance(left, FieldRef):
+        if not isinstance(left, (FieldRef, PathAccess, MetaAccess)):
             raise FilterParseError(
-                "left side of 'is null' must be a field reference",
+                "left side of 'is null' must be a field reference or JSON path",
                 self.source, is_tok.pos,
-                hint="example: title is null",
+                hint="examples: title is null, metadata[\"key\"] is null",
             )
         negate = False
         if self._peek().kind == TokenKind.NOT:
@@ -525,7 +528,23 @@ class Parser:
         return InOp(field=left, values=list_lit, negate=negate, pos=in_tok.pos)
 
     def parse_unary(self) -> Expr:
-        """prec 7: unary minus (prefix)."""
+        """prec 7: unary minus and `exists` (prefix)."""
+        if self._peek().kind == TokenKind.EXISTS:
+            exists_tok = self._consume()
+            operand = self.parse_primary()
+            if not isinstance(operand, (FieldRef, PathAccess, MetaAccess)):
+                raise FilterParseError(
+                    "'exists' must be followed by a field reference or JSON path",
+                    self.source, exists_tok.pos,
+                    hint="example: exists metadata[\"key\"]",
+                )
+            # Desugar: `exists x` ≡ `x is not null` (the server treats a
+            # missing JSON key and an explicit null identically), with
+            # from_exists letting semantic.py enforce the server's
+            # JSON-key-only restriction on EXISTS.
+            return IsNullOp(
+                field=operand, negate=True, pos=exists_tok.pos, from_exists=True,
+            )
         if self._peek().kind == TokenKind.SUB:
             sub_tok = self._consume()
             operand = self.parse_unary()

--- a/milvus_lite/search/filter/semantic.py
+++ b/milvus_lite/search/filter/semantic.py
@@ -212,7 +212,10 @@ def _rewrite_dynamic_field_refs(
         )
     if isinstance(node, IsNullOp):
         new_field = _rewrite_dynamic_field_refs(node.field, schema_fields)
-        return IsNullOp(field=new_field, negate=node.negate, pos=node.pos)
+        return IsNullOp(
+            field=new_field, negate=node.negate, pos=node.pos,
+            from_exists=node.from_exists,
+        )
     if isinstance(node, PathAccess):
         return PathAccess(
             base=_rewrite_dynamic_field_refs(node.base, schema_fields),
@@ -470,10 +473,29 @@ def _check_node(node: Expr, ctx: "_CompileCtx") -> str:
             )
         return SEM_BOOL
 
-    # ── IsNullOp (Phase F2a) ────────────────────────────────────
+    # ── IsNullOp (Phase F2a; JSON paths + exists in F2b) ────────
     if isinstance(node, IsNullOp):
-        # The parser enforces FieldRef as the operand. We don't restrict
-        # the field's type — IS NULL is meaningful for any field.
+        # The parser enforces FieldRef / PathAccess / MetaAccess as the
+        # operand. IS NULL itself is meaningful for any field, but the
+        # server restricts EXISTS to JSON keys and dynamic fields:
+        # `exists json_col` and `exists scalar_col` are both plan errors.
+        # A bare FieldRef surviving to this point is an in-schema field
+        # (unknown names were rewritten to MetaAccess when dynamic
+        # fields are enabled, and error in _check_node below otherwise).
+        if node.from_exists and isinstance(node.field, FieldRef):
+            field = ctx.schema_fields.get(node.field.name)
+            if field is not None:
+                if field.dtype == DataType.JSON:
+                    raise FilterTypeError(
+                        "'exists' on a whole JSON field is not supported, "
+                        "only on a key within it",
+                        ctx.source, node.field.pos, span=len(node.field.name),
+                    )
+                raise FilterTypeError(
+                    f"'exists' is only supported on JSON keys and dynamic "
+                    f"fields, but {node.field.name!r} is {field.dtype.value}",
+                    ctx.source, node.field.pos, span=len(node.field.name),
+                )
         _check_node(node.field, ctx)
         return SEM_BOOL
 

--- a/milvus_lite/search/filter/tokens.py
+++ b/milvus_lite/search/filter/tokens.py
@@ -68,6 +68,11 @@ class TokenKind(Enum):
     IS = "IS"
     NULL = "NULL"
 
+    # JSON key-existence test. `exists json_field["key"]` is Milvus
+    # server grammar (Plan.g4 EXISTS); the parser desugars it into
+    # IsNullOp(negate=True, from_exists=True).
+    EXISTS = "EXISTS"
+
     # Dynamic-field marker (Phase F2b). The lexer emits META on `$meta`,
     # the parser then expects '[' STRING ']' to form a MetaAccess node.
     META = "META"
@@ -99,6 +104,7 @@ _KEYWORD_MAP = {
     "like": TokenKind.LIKE, "LIKE": TokenKind.LIKE,
     "is": TokenKind.IS, "IS": TokenKind.IS,
     "null": TokenKind.NULL, "NULL": TokenKind.NULL,
+    "exists": TokenKind.EXISTS, "EXISTS": TokenKind.EXISTS,
     "iso": TokenKind.ISO, "ISO": TokenKind.ISO,
     "interval": TokenKind.INTERVAL, "INTERVAL": TokenKind.INTERVAL,
 }

--- a/tests/search/filter/test_e2e.py
+++ b/tests/search/filter/test_e2e.py
@@ -549,6 +549,11 @@ _META_DIFF_EXPRS = [
     # parser is extended to allow it (Phase F4+), add it here.
     '$meta["title"] like "AI%"',
     '$meta["nonexistent"] == "x"',
+    '$meta["priority"] is null',
+    '$meta["priority"] is not null',
+    'exists $meta["priority"]',
+    'not exists $meta["category"]',
+    'exists $meta["category"] and $meta["priority"] > 2',
 ]
 
 
@@ -625,3 +630,75 @@ def test_meta_hybrid_record_batch_input(meta_table, schema_dynamic):
     from milvus_lite.search.filter.eval.hybrid_backend import evaluate_hybrid
     result = evaluate_hybrid(compiled, batch)
     assert result.to_pylist() == [True, False, True, False, False]
+
+
+# ===========================================================================
+# Phase F2b — exists / IS NULL on JSON columns and dynamic fields
+# ===========================================================================
+#
+# Server ground truth (verified against Milvus standalone v2.5.12): both
+# `exists j["k"]` and `j["k"] is not null` match only rows where the key
+# is present AND not JSON null — a missing key and an explicit null are
+# indistinguishable.
+
+@pytest.fixture
+def schema_json():
+    return CollectionSchema(fields=[
+        FieldSchema(name="id", dtype=DataType.VARCHAR, is_primary=True),
+        FieldSchema(name="vec", dtype=DataType.FLOAT_VECTOR, dim=2),
+        FieldSchema(name="metadata", dtype=DataType.JSON),
+    ])
+
+
+@pytest.fixture
+def json_table():
+    """Rows: key present / key missing / key explicitly null."""
+    return pa.table({
+        "id": ["present", "missing", "explicit_null"],
+        "metadata": [
+            '{"agent_id": "x", "nested": {"a": 1}}',
+            '{"other": "z"}',
+            '{"agent_id": null}',
+        ],
+    })
+
+
+@pytest.mark.parametrize(
+    "expression, expected",
+    [
+        ('exists metadata["agent_id"]', [True, False, False]),
+        ('metadata["agent_id"] is not null', [True, False, False]),
+        ('metadata["agent_id"] is null', [False, True, True]),
+        ('not exists metadata["agent_id"]', [False, True, True]),
+        ('exists metadata["nested"]["a"]', [True, False, False]),
+        ('metadata["nested"]["a"] is not null', [True, False, False]),
+        ('exists metadata["agent_id"] and metadata["agent_id"] == "x"',
+         [True, False, False]),
+        ('exists metadata["agent_id"] or exists metadata["other"]',
+         [True, True, False]),
+    ],
+)
+def test_exists_and_is_null_on_json_column(
+    json_table, schema_json, expression, expected
+):
+    from milvus_lite.search.filter.eval import evaluate
+
+    compiled = compile_expr(
+        parse_expr(expression), schema_json, source=expression
+    )
+    assert compiled.backend == "python"
+    assert evaluate(compiled, json_table).to_pylist() == expected
+
+
+def test_exists_dynamic_field_via_meta(meta_table, schema_dynamic):
+    """`exists priority` on a dynamic field ≡ `exists $meta["priority"]`."""
+    from milvus_lite.search.filter.eval import evaluate
+
+    compiled = compile_expr(
+        parse_expr("exists priority"), schema_dynamic, source="exists priority"
+    )
+    assert compiled.backend == "hybrid"
+    # a, b, c have priority; d has $meta=null; e is missing the key.
+    assert evaluate(compiled, meta_table).to_pylist() == [
+        True, True, True, False, False,
+    ]

--- a/tests/search/filter/test_parser.py
+++ b/tests/search/filter/test_parser.py
@@ -21,6 +21,7 @@ from milvus_lite.search.filter.ast import (
     MetaAccess,
     Not,
     Or,
+    PathAccess,
     StringLit,
     TimestampLit,
 )
@@ -497,6 +498,91 @@ def test_is_null_in_and():
 def test_is_null_lhs_must_be_field():
     with pytest.raises(FilterParseError, match="field reference"):
         parse_expr("'literal' is null")
+
+
+def test_is_null_on_json_path():
+    e = parse_expr('metadata["key"] is null')
+    assert isinstance(e, IsNullOp)
+    assert isinstance(e.field, PathAccess)
+    assert e.field.path == ("key",)
+    assert e.negate is False
+    assert e.from_exists is False
+
+
+def test_is_not_null_on_nested_json_path():
+    e = parse_expr('metadata["a"]["b"] is not null')
+    assert isinstance(e, IsNullOp)
+    assert isinstance(e.field, PathAccess)
+    assert e.field.path == ("a", "b")
+    assert e.negate is True
+
+
+def test_is_null_on_meta_access():
+    e = parse_expr('$meta["key"] is null')
+    assert isinstance(e, IsNullOp)
+    assert isinstance(e.field, MetaAccess)
+    assert e.field.key == "key"
+    assert e.negate is False
+
+
+# ---------------------------------------------------------------------------
+# Phase F2b — exists (desugars to IS NOT NULL with from_exists)
+# ---------------------------------------------------------------------------
+
+def test_exists_on_json_path():
+    e = parse_expr('exists metadata["key"]')
+    assert isinstance(e, IsNullOp)
+    assert isinstance(e.field, PathAccess)
+    assert e.field.path == ("key",)
+    assert e.negate is True
+    assert e.from_exists is True
+
+
+def test_exists_uppercase():
+    e = parse_expr('EXISTS metadata["key"]')
+    assert isinstance(e, IsNullOp)
+    assert e.from_exists is True
+
+
+def test_exists_on_meta_access():
+    e = parse_expr('exists $meta["key"]')
+    assert isinstance(e, IsNullOp)
+    assert isinstance(e.field, MetaAccess)
+    assert e.negate is True
+
+
+def test_exists_on_bare_field():
+    """Bare identifiers parse fine — semantic.py decides whether the
+    field is dynamic (allowed) or an in-schema column (rejected)."""
+    e = parse_expr("exists dyn")
+    assert isinstance(e, IsNullOp)
+    assert isinstance(e.field, FieldRef)
+    assert e.from_exists is True
+
+
+def test_not_exists():
+    e = parse_expr('not exists metadata["key"]')
+    assert isinstance(e, Not)
+    assert isinstance(e.operand, IsNullOp)
+    assert e.operand.negate is True
+    assert e.operand.from_exists is True
+
+
+def test_exists_in_and():
+    e = parse_expr('exists metadata["a"] and metadata["a"] == "x"')
+    assert isinstance(e, And)
+    assert isinstance(e.operands[0], IsNullOp)
+    assert e.operands[0].from_exists is True
+
+
+def test_exists_requires_field_or_path():
+    with pytest.raises(FilterParseError, match="field reference or JSON path"):
+        parse_expr("exists 5")
+
+
+def test_exists_rejects_string_literal():
+    with pytest.raises(FilterParseError, match="field reference or JSON path"):
+        parse_expr("exists 'key'")
 
 
 def test_is_missing_null_keyword():

--- a/tests/search/filter/test_semantic.py
+++ b/tests/search/filter/test_semantic.py
@@ -446,3 +446,68 @@ def test_dynamic_array_functions_compile_to_python(schema_dynamic):
 def test_path_unknown_field_rejected_without_dynamic(schema):
     with pytest.raises(FilterFieldError, match="unknown field"):
         compile_str("array_field[0] < 1", schema)
+
+
+# ---------------------------------------------------------------------------
+# Phase F2b — exists / IS NULL on JSON paths
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def schema_json():
+    return CollectionSchema(fields=[
+        FieldSchema(name="id", dtype=DataType.VARCHAR, is_primary=True),
+        FieldSchema(name="vec", dtype=DataType.FLOAT_VECTOR, dim=4),
+        FieldSchema(name="metadata", dtype=DataType.JSON),
+    ])
+
+
+def test_exists_json_path_compiles_to_python(schema_json):
+    c = compile_str('exists metadata["key"]', schema_json)
+    assert c.backend == "python"
+
+
+def test_is_null_json_path_compiles_to_python(schema_json):
+    c = compile_str('metadata["key"] is not null', schema_json)
+    assert c.backend == "python"
+
+
+def test_exists_meta_access_compiles_to_hybrid(schema_dynamic):
+    c = compile_str('exists $meta["category"]', schema_dynamic)
+    assert c.backend == "hybrid"
+
+
+def test_is_null_meta_access_compiles_to_hybrid(schema_dynamic):
+    c = compile_str('$meta["category"] is null', schema_dynamic)
+    assert c.backend == "hybrid"
+
+
+def test_exists_dynamic_field_rewritten_to_meta(schema_dynamic):
+    """`exists dyn` on a dynamic field ≡ `exists $meta["dyn"]`, as on
+    the server."""
+    c = compile_str("exists dyn", schema_dynamic)
+    assert isinstance(c.ast.field, MetaAccess)
+    assert c.ast.field.key == "dyn"
+    assert c.backend == "hybrid"
+
+
+def test_exists_whole_json_field_rejected(schema_json):
+    """Server: `exists json_col` is a plan error — only keys are allowed."""
+    with pytest.raises(FilterTypeError, match="whole JSON field"):
+        compile_str("exists metadata", schema_json)
+
+
+def test_exists_scalar_field_rejected(schema):
+    """Server: exists on a non-JSON field is a plan error."""
+    with pytest.raises(FilterTypeError, match="only supported on JSON keys"):
+        compile_str("exists title", schema)
+
+
+def test_exists_unknown_field_without_dynamic_rejected(schema):
+    with pytest.raises(FilterFieldError, match="unknown field"):
+        compile_str("exists nonexistent", schema)
+
+
+def test_is_null_scalar_field_still_allowed(schema):
+    """The exists restriction must not leak into plain IS NULL."""
+    c = compile_str("title is null", schema)
+    assert c.backend == "arrow"

--- a/tests/search/filter/test_tokens.py
+++ b/tests/search/filter/test_tokens.py
@@ -382,6 +382,12 @@ def test_null_keyword(text):
     assert tokens[0].kind == TokenKind.NULL
 
 
+@pytest.mark.parametrize("text", ["exists", "EXISTS", "Exists"])
+def test_exists_keyword(text):
+    tokens = tokenize(text)
+    assert tokens[0].kind == TokenKind.EXISTS
+
+
 def test_is_null_two_tokens():
     """`is null` is two tokens; parser will combine."""
     assert kinds("title is null") == [


### PR DESCRIPTION
Closes #353

## What

Adds server-parity support for two filter spellings the parser rejected:

- `exists metadata["key"]` / `exists $meta["key"]` / `exists dyn_field` — the `EXISTS` keyword (Plan.g4) was not tokenized
- `metadata["key"] is [not] null` / `$meta["key"] is [not] null` — `IS NULL` was restricted to plain field references (the `IsNullOp` docstring marked JSON path support as a planned F2b item)

## How

- **tokens.py**: `EXISTS` keyword (case-insensitive, like the other keywords)
- **parser.py**: `exists x` desugars to `IsNullOp(negate=True, from_exists=True)` — the server treats a missing JSON key and an explicit JSON null identically, so exists and is-not-null are the same predicate. `_parse_is_null_tail` now accepts FieldRef / PathAccess / MetaAccess as LHS.
- **ast.py**: `IsNullOp.field` widened to `Expr`; new `from_exists: bool = False` marker
- **semantic.py**: enforces the server's EXISTS restriction — JSON keys and dynamic fields only. `exists json_col` (whole column) and `exists scalar_col` are compile errors with the operand named, exactly the cases the server rejects at plan time. Plain `IS NULL` on scalar fields is unaffected. The dynamic-field rewrite (`exists dyn` → `exists $meta["dyn"]`) and backend dispatch (PathAccess → python, MetaAccess → hybrid) fall out of the existing rules; the rewriters propagate the new flag.
- **python_backend.py**: `IsNullOp` evaluates its operand expression instead of assuming a FieldRef — PathAccess/MetaAccess already return `None` for missing keys, bad JSON, and explicit nulls, which is precisely the server's null semantics. hybrid needed no eval change: materialized synthetic columns already yield null for missing keys, and arrow's `pc.is_null` does the rest.

## Verification

- **Server parity**: a 16-case spec (present / missing / explicit-null rows; exists, not exists, is null, is not null, nested paths, dynamic fields, and/or combinations, whole-column and scalar error cases) run through pymilvus against Milvus standalone **v2.5.12** and against this branch — **16/16 agree** (error cases matched by kind). Happy to share the spec script.
- **Tests**: 37 new tests across test_tokens / test_parser / test_semantic / test_e2e, including three-row missing-vs-explicit-null eval tables and new entries in the hybrid-vs-python differential parity list. Full suite: **2415 passed, 34 skipped** (baseline before the change: 2378 passed).

## Downstream context

mem0's Milvus vector store now emits `exists metadata["key"]` for its documented "any value" wildcard (mem0ai/mem0#6540); that filter works on a server deployment and raises a parse error on milvus-lite local mode.
