### PR TITLE
fix: select segment indexes by vector field

### DIFF
--- a/milvus_lite/search/executor_indexed.py
+++ b/milvus_lite/search/executor_indexed.py
@@ -24,10 +24,10 @@ Differs from `execute_search` in two architectural ways:
 Result-equivalence with the old path is guaranteed by the
 differential test in tests/search/test_executor_with_index.py.
 
-Phase 9.2 always builds an ad-hoc BruteForceIndex if `segment.index`
-is None — this exercises the new architecture from day one even
-before Collection.create_index lands in 9.3. Building a BruteForceIndex
-is essentially free (just stores a numpy reference).
+Phase 9.2 always builds an ad-hoc BruteForceIndex if the segment has no
+index for the selected vector field — this exercises the new architecture
+from day one even before Collection.create_index lands in 9.3. Building a
+BruteForceIndex is essentially free (just stores a numpy reference).
 """
 
 from __future__ import annotations
@@ -212,21 +212,22 @@ def execute_search_with_index(
 
     # Segments first.
     for seg in in_scope_segments:
-        sources.append((list(seg.pks), seg.seqs, seg.vectors))
+        seg_vectors, seg_vector_null_mask = seg.vector_data(vector_field)
+        sources.append((list(seg.pks), seg.seqs, seg_vectors))
         # Combine scalar filter mask with vector null mask
         combined_mask = seg_filter_masks.get(id(seg))
-        if seg.vector_null_mask is not None:
+        if seg_vector_null_mask is not None:
             if combined_mask is not None:
-                combined_mask = combined_mask & seg.vector_null_mask
+                combined_mask = combined_mask & seg_vector_null_mask
             else:
-                combined_mask = seg.vector_null_mask
+                combined_mask = seg_vector_null_mask
         _recall_source(
             source_idx=len(sources) - 1,
             pks=sources[-1][0],
             seqs=sources[-1][1],
             vectors=sources[-1][2],
             filter_mask=combined_mask,
-            index=seg.index,
+            index=seg.indexes.get(vector_field),
         )
 
     # Memtable last (always brute-force; never has an attached index).

--- a/milvus_lite/storage/segment.py
+++ b/milvus_lite/storage/segment.py
@@ -68,6 +68,7 @@ class Segment:
         "scalar_indexes",
         "_pk_field",
         "_vector_field",
+        "_vector_data_by_field",
     )
 
     def __init__(
@@ -93,6 +94,13 @@ class Segment:
         # Boolean mask: True = vector is valid, False = null vector.
         # None means all vectors are valid (no nullable vector field).
         self.vector_null_mask = vector_null_mask
+        self._vector_data_by_field: Dict[
+            str, Tuple[np.ndarray, Optional[np.ndarray]]
+        ] = {}
+        if vector_field:
+            self._vector_data_by_field[vector_field] = (
+                vectors, vector_null_mask,
+            )
         self.pk_to_row: Dict[Any, int] = {pk: i for i, pk in enumerate(pks)}
         # Phase 9.2 / Phase 18: per-field attached indexes.
         # self.index is backward-compat shortcut (first/only index).
@@ -252,15 +260,11 @@ class Segment:
         )
 
         path = self.index_file_path(index_dir, spec.index_type, field_name)
+        vectors, _ = self.vector_data(field_name)
 
         if os.path.exists(path):
-            idx = load_index_from_spec(spec, path, self.vector_dim)
+            idx = load_index_from_spec(spec, path, vectors.shape[1])
         else:
-            # Use the correct vector data for the requested field
-            if field_name == self._vector_field:
-                vectors = self.vectors
-            else:
-                vectors, _ = _extract_vector_array(self.table.column(field_name))
             idx = build_index_from_spec(spec, vectors)
             os.makedirs(index_dir, exist_ok=True)
             idx.save(path)
@@ -302,6 +306,16 @@ class Segment:
     @property
     def vector_dim(self) -> int:
         return self.vectors.shape[1] if self.vectors.size > 0 else 0
+
+    def vector_data(
+        self, field_name: str
+    ) -> Tuple[np.ndarray, Optional[np.ndarray]]:
+        """Return vectors and null mask for a dense vector field."""
+        cached = self._vector_data_by_field.get(field_name)
+        if cached is None:
+            cached = _extract_vector_array(self.table.column(field_name))
+            self._vector_data_by_field[field_name] = cached
+        return cached
 
 
 # ---------------------------------------------------------------------------

--- a/tests/engine/test_anns_field.py
+++ b/tests/engine/test_anns_field.py
@@ -3,6 +3,7 @@
 Covers:
 - Default anns_field (None → first FLOAT_VECTOR)
 - Explicit anns_field pointing to FLOAT_VECTOR works
+- Explicit anns_field selects the matching data and index with multiple dense fields
 - Explicit anns_field pointing to SPARSE_FLOAT_VECTOR raises NotImplementedError
 - Invalid anns_field raises SchemaValidationError
 - Non-vector anns_field raises SchemaValidationError
@@ -11,6 +12,7 @@ Covers:
 from contextlib import closing
 import tempfile
 
+import numpy as np
 import pytest
 
 from milvus_lite.engine.collection import Collection
@@ -58,6 +60,12 @@ def _mixed_collection(tmpdir):
     return col
 
 
+def _vector(dim: int, position: int) -> list[float]:
+    vector = np.zeros(dim, dtype=np.float32)
+    vector[position] = 1.0
+    return vector.tolist()
+
+
 class TestAnnsField:
     def test_default_uses_float_vector(self):
         """anns_field=None defaults to the FLOAT_VECTOR field."""
@@ -85,6 +93,49 @@ class TestAnnsField:
             )
             assert len(results) == 1
             assert len(results[0]) == 2
+
+    def test_explicit_field_selects_matching_segment_index(self):
+        """Each dense field uses its own segment vectors and index."""
+        with tempfile.TemporaryDirectory() as d:
+            schema = CollectionSchema(fields=[
+                FieldSchema(name="id", dtype=DataType.INT64, is_primary=True),
+                FieldSchema(name="vec768", dtype=DataType.FLOAT_VECTOR, dim=768),
+                FieldSchema(name="vec3072", dtype=DataType.FLOAT_VECTOR, dim=3072),
+            ])
+            with closing(Collection(name="multi", data_dir=d, schema=schema)) as col:
+                col.insert([
+                    {
+                        "id": 1,
+                        "vec768": _vector(768, 0),
+                        "vec3072": _vector(3072, 1),
+                    },
+                    {
+                        "id": 2,
+                        "vec768": _vector(768, 1),
+                        "vec3072": _vector(3072, 0),
+                    },
+                ])
+                col.flush()
+                index_params = {
+                    "index_type": "BRUTE_FORCE",
+                    "metric_type": "L2",
+                    "params": {},
+                }
+                col.create_index("vec768", index_params)
+                col.create_index("vec3072", index_params)
+                col.load()
+
+                first = col.search(
+                    [_vector(768, 0)], top_k=1, metric_type="L2",
+                    anns_field="vec768",
+                )
+                second = col.search(
+                    [_vector(3072, 0)], top_k=1, metric_type="L2",
+                    anns_field="vec3072",
+                )
+
+                assert first[0][0]["id"] == 1
+                assert second[0][0]["id"] == 2
 
     def test_sparse_search_works(self):
         """Searching on SPARSE_FLOAT_VECTOR with BM25 works."""

--- a/tests/engine/test_collection_index_persistence.py
+++ b/tests/engine/test_collection_index_persistence.py
@@ -41,6 +41,12 @@ def _vec(i):
     return [float(i), float(i + 1), float(i + 2), float(i + 3)]
 
 
+def _unit_vector(dim: int, position: int) -> list[float]:
+    vector = np.zeros(dim, dtype=np.float32)
+    vector[position] = 1.0
+    return vector.tolist()
+
+
 BRUTE_PARAMS = {"index_type": "BRUTE_FORCE", "metric_type": "L2", "params": {}}
 
 
@@ -162,6 +168,46 @@ def test_restart_load_then_search_results_correct(tmp_path, schema):
         assert [r["id"] for r in actual[0]] == [r["id"] for r in expected[0]]
     finally:
         c2.close()
+
+
+def test_restart_load_uses_each_vector_field_dimension(tmp_path):
+    schema = CollectionSchema(fields=[
+        FieldSchema(name="id", dtype=DataType.INT64, is_primary=True),
+        FieldSchema(name="vec768", dtype=DataType.FLOAT_VECTOR, dim=768),
+        FieldSchema(name="vec3072", dtype=DataType.FLOAT_VECTOR, dim=3072),
+    ])
+    data_dir = str(tmp_path / "data")
+    collection = Collection("multi", data_dir, schema)
+    collection.insert([
+        {
+            "id": 1,
+            "vec768": _unit_vector(768, 0),
+            "vec3072": _unit_vector(3072, 0),
+        },
+        {
+            "id": 2,
+            "vec768": _unit_vector(768, 1),
+            "vec3072": _unit_vector(3072, 1),
+        },
+    ])
+    collection.flush()
+    collection.create_index("vec768", BRUTE_PARAMS)
+    collection.create_index("vec3072", BRUTE_PARAMS)
+    collection.load()
+    collection.close()
+
+    reopened = Collection("multi", data_dir, schema)
+    try:
+        reopened.load()
+        result = reopened.search(
+            [_unit_vector(3072, 1)],
+            top_k=1,
+            metric_type="L2",
+            anns_field="vec3072",
+        )
+        assert result[0][0]["id"] == 2
+    finally:
+        reopened.close()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/storage/test_segment.py
+++ b/tests/storage/test_segment.py
@@ -86,6 +86,41 @@ def test_load_vectors_values(parquet_file):
     )
 
 
+def test_vector_data_caches_non_default_field(tmp_path):
+    pks = ["a", "b"]
+    seqs = np.array([1, 2], dtype=np.uint64)
+    first_vectors = np.array([[1.0, 0.0], [0.0, 1.0]], dtype=np.float32)
+    table = pa.table({
+        "id": pks,
+        "_seq": seqs,
+        "first": pa.array(first_vectors.tolist(), type=pa.list_(pa.float32(), 2)),
+        "second": pa.array(
+            [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]],
+            type=pa.list_(pa.float32(), 3),
+        ),
+    })
+    segment = Segment(
+        file_path=str(tmp_path / "fake.parquet"),
+        partition="_default",
+        pk_field="id",
+        vector_field="first",
+        pks=pks,
+        seqs=seqs,
+        vectors=first_vectors,
+        table=table,
+    )
+
+    vectors, null_mask = segment.vector_data("second")
+    cached_vectors, cached_null_mask = segment.vector_data("second")
+
+    assert vectors is cached_vectors
+    assert null_mask is cached_null_mask
+    np.testing.assert_array_equal(
+        vectors,
+        np.array([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]], dtype=np.float32),
+    )
+
+
 # ---------------------------------------------------------------------------
 # pk_to_row + find_row
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #358

## What

Fix indexed search and cold index loading for collections with multiple dense vector fields, especially when the fields have different dimensions.

After data was flushed into segments, search on a non-default `anns_field` used the first dense field's vector matrix and index. After restart, loading that field's sidecar validated it against the first field's dimension. This caused shape errors for asymmetric dimensions and could silently search the wrong field when dimensions matched.

## How

- Add a field-aware `Segment.vector_data()` accessor with per-field lazy caching.
- Select segment vectors, null masks, and attached indexes using the resolved `vector_field` in the indexed executor.
- Validate persisted sidecars against the selected field's actual vector dimension.
- Add asymmetric 768/3072 regression coverage to the existing `anns_field` and index-persistence test modules.
- Add a Segment regression test proving non-default vector data is cached instead of re-extracted on every search.

## Verification

- Targeted regression and adjacent tests: **32 passed**
- Core suite: **1777 passed, 10 skipped, 5 deselected**
- `python -m build`: wheel and sdist built successfully
