### PR TITLE
fix(grpc): report in-memory percentages in show responses

### DIFF
--- a/milvus_lite/adapter/grpc/servicer.py
+++ b/milvus_lite/adapter/grpc/servicer.py
@@ -270,16 +270,29 @@ class MilvusServicer(milvus_pb2_grpc.MilvusServiceServicer):
             )
 
     def ShowCollections(self, request, context):
-        """Return the list of collection names. Milvus's response also
-        carries timestamps and IDs which we don't track — those slots
-        stay empty."""
+        """Return collection names and their in-memory load status."""
         try:
+            database_name = self._database_name(request, context)
             names = self._db.list_collections(
-                database_name=self._database_name(request, context),
+                database_name=database_name,
             )
+            if request.collection_names:
+                requested = set(request.collection_names)
+                names = [name for name in names if name in requested]
+            percentages = [
+                100
+                if self._db.get_collection(
+                    name, database_name=database_name
+                ).load_state == "loaded"
+                else 0
+                for name in names
+            ]
             return milvus_pb2.ShowCollectionsResponse(
                 status=common_pb2.Status(**success_status_kwargs()),
                 collection_names=names,
+                inMemory_percentages=percentages,
+                query_service_available=[value == 100 for value in percentages],
+                shards_num=[1] * len(names),
             )
         except Exception as e:
             logger.exception("ShowCollections failed: %s", e)
@@ -937,9 +950,14 @@ class MilvusServicer(milvus_pb2_grpc.MilvusServiceServicer):
         try:
             col = self._get_collection(request, context)
             names = col.list_partitions()
+            if request.partition_names:
+                requested = set(request.partition_names)
+                names = [name for name in names if name in requested]
+            percentage = 100 if col.load_state == "loaded" else 0
             return milvus_pb2.ShowPartitionsResponse(
                 status=common_pb2.Status(**success_status_kwargs()),
                 partition_names=names,
+                inMemory_percentages=[percentage] * len(names),
             )
         except MilvusLiteError as e:
             return milvus_pb2.ShowPartitionsResponse(

--- a/tests/adapter/test_grpc_show_in_memory.py
+++ b/tests/adapter/test_grpc_show_in_memory.py
@@ -1,0 +1,144 @@
+"""Compatibility tests for ShowCollections/ShowPartitions InMemory responses."""
+
+import grpc
+import pytest
+from pymilvus import DataType, MilvusClient
+from pymilvus.grpc_gen import milvus_pb2, milvus_pb2_grpc
+
+
+def _make_schema():
+    schema = MilvusClient.create_schema(auto_id=False)
+    schema.add_field("id", DataType.INT64, is_primary=True)
+    schema.add_field("vec", DataType.FLOAT_VECTOR, dim=4)
+    return schema
+
+
+def _make_index_params(client):
+    params = client.prepare_index_params()
+    params.add_index(
+        field_name="vec",
+        index_type="BRUTE_FORCE",
+        metric_type="L2",
+        params={},
+    )
+    return params
+
+
+@pytest.fixture
+def raw_stub(grpc_server):
+    port, _db = grpc_server
+    channel = grpc.insecure_channel(f"127.0.0.1:{port}")
+    try:
+        yield milvus_pb2_grpc.MilvusServiceStub(channel)
+    finally:
+        channel.close()
+
+
+def test_show_collections_in_memory_reports_loaded_percentage(
+    milvus_client, raw_stub
+):
+    milvus_client.create_collection("demo", schema=_make_schema())
+
+    response = raw_stub.ShowCollections(
+        milvus_pb2.ShowCollectionsRequest(
+            type=milvus_pb2.ShowType.InMemory,
+            collection_names=["demo"],
+        )
+    )
+
+    assert list(response.collection_names) == ["demo"]
+    assert list(response.inMemory_percentages) == [100]
+    assert list(response.query_service_available) == [True]
+    assert list(response.shards_num) == [1]
+
+
+def test_show_collections_in_memory_reports_released_percentage(
+    milvus_client, raw_stub
+):
+    milvus_client.create_collection("demo", schema=_make_schema())
+    milvus_client.create_index("demo", _make_index_params(milvus_client))
+    milvus_client.release_collection("demo")
+
+    response = raw_stub.ShowCollections(
+        milvus_pb2.ShowCollectionsRequest(
+            type=milvus_pb2.ShowType.InMemory,
+            collection_names=["demo"],
+        )
+    )
+
+    assert list(response.collection_names) == ["demo"]
+    assert list(response.inMemory_percentages) == [0]
+    assert list(response.query_service_available) == [False]
+    assert list(response.shards_num) == [1]
+
+
+def test_show_collections_in_memory_filters_requested_names(
+    milvus_client, raw_stub
+):
+    milvus_client.create_collection("alpha", schema=_make_schema())
+    milvus_client.create_collection("beta", schema=_make_schema())
+
+    response = raw_stub.ShowCollections(
+        milvus_pb2.ShowCollectionsRequest(
+            type=milvus_pb2.ShowType.InMemory,
+            collection_names=["beta"],
+        )
+    )
+
+    assert list(response.collection_names) == ["beta"]
+    assert list(response.inMemory_percentages) == [100]
+
+
+def test_show_partitions_in_memory_reports_collection_load_percentage(
+    milvus_client, raw_stub
+):
+    milvus_client.create_collection("demo", schema=_make_schema())
+    milvus_client.create_partition("demo", "p1")
+
+    response = raw_stub.ShowPartitions(
+        milvus_pb2.ShowPartitionsRequest(
+            collection_name="demo",
+            type=milvus_pb2.ShowType.InMemory,
+        )
+    )
+
+    assert list(response.partition_names) == ["_default", "p1"]
+    assert list(response.inMemory_percentages) == [100, 100]
+
+
+def test_show_partitions_in_memory_reports_released_collection(
+    milvus_client, raw_stub
+):
+    milvus_client.create_collection("demo", schema=_make_schema())
+    milvus_client.create_partition("demo", "p1")
+    milvus_client.create_index("demo", _make_index_params(milvus_client))
+    milvus_client.release_collection("demo")
+
+    response = raw_stub.ShowPartitions(
+        milvus_pb2.ShowPartitionsRequest(
+            collection_name="demo",
+            type=milvus_pb2.ShowType.InMemory,
+        )
+    )
+
+    assert list(response.partition_names) == ["_default", "p1"]
+    assert list(response.inMemory_percentages) == [0, 0]
+
+
+def test_show_partitions_in_memory_filters_requested_names(
+    milvus_client, raw_stub
+):
+    milvus_client.create_collection("demo", schema=_make_schema())
+    milvus_client.create_partition("demo", "p1")
+    milvus_client.create_partition("demo", "p2")
+
+    response = raw_stub.ShowPartitions(
+        milvus_pb2.ShowPartitionsRequest(
+            collection_name="demo",
+            type=milvus_pb2.ShowType.InMemory,
+            partition_names=["p2"],
+        )
+    )
+
+    assert list(response.partition_names) == ["p2"]
+    assert list(response.inMemory_percentages) == [100]

--- a/tests/engine/test_scalar_index.py
+++ b/tests/engine/test_scalar_index.py
@@ -5,6 +5,7 @@ import pytest
 
 from milvus_lite import Collection, CollectionSchema, DataType, FieldSchema
 from milvus_lite.exceptions import SchemaValidationError
+from milvus_lite.index.scalar import ScalarInvertedIndex
 
 
 def _schema():
@@ -511,14 +512,12 @@ def test_load_rejects_scalar_sidx_dtype_metadata_mismatch(tmp_path):
 
         index_dir = data_dir / "partitions" / "_default" / "indexes"
         sidx_path = next(index_dir.glob("*.age.inverted.sidx"))
-        with pa.OSFile(str(sidx_path), "rb") as source:
-            table = pa.ipc.RecordBatchFileReader(source).read_all()
-        metadata = dict(table.schema.metadata or {})
-        metadata[b"dtype"] = b"VARCHAR"
-        table = table.replace_schema_metadata(metadata)
-        with pa.OSFile(str(sidx_path), "wb") as sink:
-            with pa.ipc.RecordBatchFileWriter(sink, table.schema) as writer:
-                writer.write_table(table)
+        wrong_dtype_index = ScalarInvertedIndex.build(
+            pa.table({"age": ["18", "25", "30", "50", None]}),
+            "age",
+            DataType.VARCHAR,
+        )
+        wrong_dtype_index.save(str(sidx_path))
 
         with pytest.raises(ValueError, match="metadata does not match"):
             col.load()

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -614,6 +614,10 @@ else:
         capture_output=True,
         text=True,
         timeout=10,
+        # Keep POSIX on the posix_spawn path.  Forking the full pytest
+        # process is unsafe once the session-scoped gRPC server has
+        # started worker threads and can intermittently SIGTRAP on macOS.
+        close_fds=sys.platform == "win32",
     )
     if result.returncode != 0:
         return (


### PR DESCRIPTION
  Populate load percentages for ShowCollections and ShowPartitions based
  on collection load state. Filter responses by requested collection or
  partition names, and include query availability and shard counts.

  Add gRPC regression tests covering loaded, released, and filtered
  collection and partition responses.

  Fixes #361