### PR TITLE
fix: order query iterator results by primary key

### DIFF
--- a/docs/modules.md
+++ b/docs/modules.md
@@ -1788,22 +1788,29 @@ class Collection:
 
     def query(                                       # Phase 8 new method
         self,
-        expr: str,
+        expr: Optional[str] = None,
         output_fields: Optional[List[str]] = None,
         partition_names: Optional[List[str]] = None,
         limit: Optional[int] = None,
+        offset: int = 0,
+        timezone: Optional[str] = None,
+        order_by_pk: bool = False,
     ) -> List[dict]:
         """Pure scalar query (no vectors, no distance).
 
         Flow: parse_expr -> compile_expr -> assemble_candidates(no query) ->
               build_valid_mask(filter_mask=...) -> take all True rows ->
-              project output_fields -> truncate to limit.
+              optionally order by primary key -> apply offset/limit ->
+              project output_fields.
 
         Args:
-            expr: Required, filter expression (see sections 9.19-9.25)
+            expr: Optional filter expression (see sections 9.19-9.25)
             output_fields: List of fields to return, None returns all fields (excluding _seq, _partition)
             partition_names: Search scope
             limit: Maximum number of rows to return (None = unlimited)
+            offset: Number of ordered or physical rows to skip
+            timezone: Optional timezone used to interpret TIMESTAMPTZ expressions
+            order_by_pk: Sort by primary key before offset/limit; enabled by the gRPC adapter for query iterators
 
         Returns:
             List[dict], each dict is one matching record
@@ -2611,7 +2618,7 @@ def run_server(
 | `Insert` / `Upsert` | `col.insert(records, partition)` | translator: records.py — FieldData column-row transposition |
 | `Delete(ids=)` | `col.delete(pks, partition)` | |
 | `Delete(filter=)` | `col.query(filter) -> extract pk -> col.delete` | |
-| `Query` | `col.query(expr, output_fields, partition_names, limit)` or `col.get(pks, ...)` | id expression goes to get |
+| `Query` | `col.query(expr, output_fields, partition_names, limit)` or `col.get(pks, ...)` | id expression goes to get; iterator requests use PK-ordered `col.query` |
 | `Search` | `col.search(query_vectors, top_k, metric_type, partition_names, expr, output_fields)` | translator: search.py + result.py; supports exactly one public L2 Function Chain; public Function Chains reject FunctionScore/ranker and `order_by_fields` before ANN Search |
 | `HybridSearch` | existing hybrid rerank path | Public Function Chains are unsupported and rejected |
 | `CreateIndex` | `col.create_index(field, params)` | translator: index.py |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -762,7 +762,7 @@ Search → top-N candidates → group by group_by_field → top group_size per g
 
 ## Phase 16 — Iterator (query_iterator / search_iterator)
 
-**Completed.** query(expr=None) returns all records, supports pymilvus client-side pk cursor pagination and distance range pagination.
+**Completed.** query(expr=None) returns all records, supports pymilvus client-side pk cursor pagination with stable primary-key ordering, and distance range pagination.
 
 ---
 

--- a/milvus_lite/adapter/grpc/servicer.py
+++ b/milvus_lite/adapter/grpc/servicer.py
@@ -425,6 +425,7 @@ class MilvusServicer(milvus_pb2_grpc.MilvusServiceServicer):
             # Extract limit and offset from query_params KV list.
             limit = None
             offset = 0
+            iterator_request = False
             timezone = _extract_timezone(request.query_params)
             time_fields = _extract_time_fields(request.query_params)
             for kv in request.query_params:
@@ -438,6 +439,11 @@ class MilvusServicer(milvus_pb2_grpc.MilvusServiceServicer):
                         offset = int(kv.value)
                     except (ValueError, TypeError):
                         pass
+                elif kv.key == "iterator":
+                    # QueryIterator uses iterator=False while seeking to an
+                    # initial offset, but that request still advances a PK
+                    # cursor and therefore needs the same stable ordering.
+                    iterator_request = True
 
             # Handle count(*) aggregation
             if output_fields and "count(*)" in output_fields:
@@ -468,7 +474,14 @@ class MilvusServicer(milvus_pb2_grpc.MilvusServiceServicer):
             )
 
             expr = request.expr if request.expr else None
-            pks = self._extract_pks_from_expr(expr, col) if expr else None
+            # Cursor pagination adds ``pk > last_pk`` between requests and
+            # therefore requires every page to be in primary-key order.  It
+            # must also avoid the get-by-PK fast path, which preserves input
+            # order rather than sorting by primary key.
+            pks = (
+                self._extract_pks_from_expr(expr, col)
+                if expr and not iterator_request else None
+            )
             if pks is not None:
                 rows = col.get(pks, partition_names=partition_names,
                                output_fields=output_fields)
@@ -480,6 +493,7 @@ class MilvusServicer(milvus_pb2_grpc.MilvusServiceServicer):
                     limit=limit,
                     offset=offset,
                     timezone=timezone,
+                    order_by_pk=iterator_request,
                 )
 
             return milvus_pb2.QueryResults(

--- a/milvus_lite/engine/collection.py
+++ b/milvus_lite/engine/collection.py
@@ -1131,6 +1131,7 @@ class Collection:
         limit: Optional[int] = None,
         offset: int = 0,
         timezone: Optional[str] = None,
+        order_by_pk: bool = False,
     ) -> List[dict]:
         """Pure scalar query — no vector, no distance.
 
@@ -1146,11 +1147,16 @@ class Collection:
                 The pk field is always included.
             partition_names: optional partition filter
             limit: max number of rows to return; None = unbounded
+            offset: number of matching rows to skip
+            timezone: optional timezone for TIMESTAMPTZ expressions
+            order_by_pk: sort live rows by primary key before applying
+                offset/limit. Used by cursor-based query iterators.
 
         Returns:
-            List of dicts (each a record matching the filter). Order is
-            "segments first, then MemTable" — within each source, the
-            order is the underlying iteration order. No top-k sort.
+            List of dicts (each a record matching the filter). By default,
+            order is "segments first, then MemTable" and follows each
+            source's underlying iteration order. With order_by_pk, rows are
+            returned in ascending primary-key order.
         """
         if expr is not None and not isinstance(expr, str):
             raise TypeError("query() expr must be a string or None")
@@ -1190,6 +1196,11 @@ class Collection:
         # Deferred materialization: only materialize records that pass the mask.
         effective_limit = (offset + limit) if limit is not None else None
         live_indices = np.flatnonzero(mask)
+        if order_by_pk:
+            live_indices = sorted(
+                live_indices,
+                key=lambda index: all_pks[int(index)],
+            )
         out: List[dict] = []
         for i in live_indices:
             rec = materialize_record(all_rec_sources[int(i)])

--- a/tests/adapter/test_iterator.py
+++ b/tests/adapter/test_iterator.py
@@ -8,8 +8,9 @@ Covers:
 1. query_iterator: paginate all records in batches
 2. query_iterator with filter
 3. query_iterator collects all records without duplicates
-4. search_iterator: paginate search results in batches
-5. Engine: query(expr=None) returns all records
+4. query_iterator orders VARCHAR primary keys, PK-IN filters, and offset seeks
+5. search_iterator: paginate search results in batches
+6. Engine: query(expr=None) returns all records
 """
 
 from contextlib import closing
@@ -84,6 +85,36 @@ class TestQueryAllRecords:
                 results = col.query(None, limit=5)
                 assert len(results) == 5
 
+    def test_query_order_by_pk_applies_before_pagination_and_is_opt_in(self):
+        from milvus_lite.schema.types import (
+            CollectionSchema, DataType as LDT, FieldSchema,
+        )
+        from milvus_lite.engine.collection import Collection
+
+        with tempfile.TemporaryDirectory() as d:
+            schema = CollectionSchema(fields=[
+                FieldSchema(
+                    name="id", dtype=LDT.VARCHAR, is_primary=True,
+                    max_length=8,
+                ),
+                FieldSchema(name="vec", dtype=LDT.FLOAT_VECTOR, dim=4),
+            ])
+            with closing(Collection(name="t", data_dir=d, schema=schema)) as col:
+                inserted_ids = ["f", "a", "e", "b", "d", "c"]
+                col.insert([
+                    {"id": pk, "vec": [float(i), 0, 0, 0]}
+                    for i, pk in enumerate(inserted_ids)
+                ])
+
+                # Regular query keeps its existing physical-order semantics.
+                assert [r["id"] for r in col.query(None)] == inserted_ids
+                # Iterator pagination requires sorting before offset/limit.
+                rows = col.query(
+                    None, output_fields=["id"], limit=2, offset=1,
+                    order_by_pk=True,
+                )
+                assert [r["id"] for r in rows] == ["b", "c"]
+
 
 # ---------------------------------------------------------------------------
 # gRPC integration tests
@@ -106,6 +137,27 @@ def _setup_collection(client, name, n=20):
                   metric_type="COSINE", params={})
     client.create_index(name, idx)
     client.load_collection(name)
+
+
+def _setup_unsorted_varchar_collection(client, name):
+    schema = MilvusClient.create_schema()
+    schema.add_field(
+        "id", DataType.VARCHAR, is_primary=True, max_length=8,
+    )
+    schema.add_field("vec", DataType.FLOAT_VECTOR, dim=4)
+    schema.add_field("category", DataType.VARCHAR, max_length=8)
+    client.create_collection(name, schema=schema)
+
+    inserted_ids = ["f", "a", "e", "b", "h", "c", "g", "d"]
+    client.insert(name, [
+        {
+            "id": pk,
+            "vec": [float(i), 0.0, 0.0, 0.0],
+            "category": "keep",
+        }
+        for i, pk in enumerate(inserted_ids)
+    ])
+    return inserted_ids
 
 
 def test_query_iterator_all_records(milvus_client):
@@ -175,6 +227,82 @@ def test_query_iterator_no_duplicates(milvus_client):
 
     assert len(seen) == 50
     milvus_client.drop_collection("qi_nodup")
+
+
+def test_query_iterator_unsorted_varchar_pk_exactly_once(milvus_client):
+    """Regression for #366: cursor paging requires PK-ordered pages."""
+    inserted_ids = _setup_unsorted_varchar_collection(
+        milvus_client, "qi_varchar_unsorted",
+    )
+
+    it = milvus_client.query_iterator(
+        "qi_varchar_unsorted",
+        batch_size=3,
+        filter='category == "keep"',
+        output_fields=["id"],
+        limit=-1,
+    )
+    returned_ids = []
+    while True:
+        batch = it.next()
+        if not batch:
+            break
+        returned_ids.extend(row["id"] for row in batch)
+    it.close()
+
+    assert returned_ids == sorted(inserted_ids)
+
+
+def test_query_iterator_pk_in_filter_uses_ordered_query_path(milvus_client):
+    """Iterator mode must not use the unordered primary-key get fast path."""
+    inserted_ids = _setup_unsorted_varchar_collection(
+        milvus_client, "qi_varchar_pk_in",
+    )
+    filter_expr = "id in [" + ", ".join(
+        f'"{pk}"' for pk in inserted_ids
+    ) + "]"
+
+    it = milvus_client.query_iterator(
+        "qi_varchar_pk_in",
+        batch_size=3,
+        filter=filter_expr,
+        output_fields=["id"],
+        limit=-1,
+    )
+    returned_ids = []
+    while True:
+        batch = it.next()
+        if not batch:
+            break
+        returned_ids.extend(row["id"] for row in batch)
+    it.close()
+
+    assert returned_ids == sorted(inserted_ids)
+
+
+def test_query_iterator_offset_uses_ordered_seek_path(milvus_client):
+    """The iterator's internal iterator=False seek requests still need order."""
+    inserted_ids = _setup_unsorted_varchar_collection(
+        milvus_client, "qi_varchar_offset",
+    )
+
+    it = milvus_client.query_iterator(
+        "qi_varchar_offset",
+        batch_size=2,
+        filter='category == "keep"',
+        output_fields=["id"],
+        offset=3,
+        limit=-1,
+    )
+    returned_ids = []
+    while True:
+        batch = it.next()
+        if not batch:
+            break
+        returned_ids.extend(row["id"] for row in batch)
+    it.close()
+
+    assert returned_ids == sorted(inserted_ids)[3:]
 
 
 def test_search_iterator(milvus_client):


### PR DESCRIPTION
Sort query iterator results by primary key before applying offset and limit so pymilvus can safely use the last returned key as its cursor.

Bypass the get-by-PK fast path for iterator requests and preserve ordering for offset seek requests where pymilvus sends iterator=False.

Add regression tests for unordered VARCHAR primary keys, PK-IN filters, and iterator offsets.

Fixes #366